### PR TITLE
Guri

### DIFF
--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -24,7 +24,7 @@
 
 
 // how many frames before we consider a face "lost"
-#define NUM_FRAMES_TO_LOSE_FACE			(0)
+#define NUM_FRAMES_TO_LOSE_FACE			(1)
 
 
 namespace smll {

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -24,7 +24,7 @@
 
 
 // how many frames before we consider a face "lost"
-#define NUM_FRAMES_TO_LOSE_FACE			(30)
+#define NUM_FRAMES_TO_LOSE_FACE			(0)
 
 
 namespace smll {


### PR DESCRIPTION
 ### Problem

#### Late Update of a mask location when:

- Moving a face fast to completely new location
- Removing face (no face anymore)

### Solution
Reducing time of keeping the old face (30 frames ~ 1.2 seconds) is too much time, setting the number to 1 is better since it handles if there is a single error and makes a real-time performance for moving the face.