### PR TITLE
Freezing Frame Issue

### DIFF
--- a/face-mask-filter.cpp
+++ b/face-mask-filter.cpp
@@ -192,9 +192,7 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 		detection.frameIndex = -1;
 		detection.facesIndex = -1;
 		detection.thread = std::thread(StaticThreadMain, this);
-		for (int i = 0; i < ThreadData::BUFFER_SIZE; i++) {
-			detection.frames[i].active = false;
-		}
+		clearFramesActiveStatus();
 	}
 	
 	// start mask data loading thread
@@ -750,6 +748,15 @@ void Plugin::FaceMaskFilter::Instance::video_render(void *ptr,
 	reinterpret_cast<Instance*>(ptr)->video_render(effect);
 }
 
+/*
+ * Sets frames active status to false
+ */
+void Plugin::FaceMaskFilter::Instance::clearFramesActiveStatus() {
+	for (int i = 0; i < ThreadData::BUFFER_SIZE; i++) {
+		detection.frames[i].active = false;
+	}
+}
+
 void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 
 	// Skip rendering if inactive or invisible.
@@ -760,6 +767,8 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 		std::unique_lock<std::mutex> lock(detection.mutex);
 		detection.frameIndex = -1;
 		detection.facesIndex = -1;
+
+		clearFramesActiveStatus();
 		// make sure file loads still happen
 		checkForMaskUnloading();
 		// *** SKIP ***

--- a/face-mask-filter.h
+++ b/face-mask-filter.h
@@ -58,7 +58,7 @@ namespace Plugin {
 
 	private:
 		obs_source_info filter;
-
+		
 		class Instance {
 		public:
 			Instance(obs_data_t *, obs_source_t *);
@@ -115,6 +115,7 @@ namespace Plugin {
 				bool isAlert);
 			gs_texture* RenderSourceTexture(gs_effect_t* effect);
 			bool SendSourceTextureToThread(gs_texture* sourceTexture);
+			void clearFramesActiveStatus();
 
 		private:
 			// Filter State


### PR DESCRIPTION
### Problem

Old frame is stuck during the mask play, new frame can't be sent.

##### State:
Played a new mask:
The frame_index = -1 (since a new mask) 
and the last frame status = active (just random stop of the mask) [the problem happens only that time]
##### Note
Because Mask is stopped at randomly, the status of the last frame in the buffer(7) can be kept as active.

In the video render, thread keeps trying to send a new frame unsucessfuly:
~~~~
bool Plugin::FaceMaskFilter::Instance::SendSourceTextureToThread(gs_texture* sourceTexture) {
....
	if (detection.frames[last_idx].active)
		return false;  
.....
}
~~~~

Detector tries to get a new frame but the frame_index = -1 , and it is skipped all time
~~~~
int32_t Plugin::FaceMaskFilter::Instance::LocalThreadMain() {
...
if (frame_idx < 0) {
			std::this_thread::sleep_for(std::chrono::milliseconds(16));
			continue;
		}
}
~~~~

That's why, when randomly the status of 7's frame (the last in the buffer) is kept as active (Since we don;t know whet it is stopped), 
and facemask is activated it always take an old frame.

### Solution
Clear the status of frames when the mask is disabled and at the start, there will be no problem in sending a new frame.

~~~~
void Plugin::FaceMaskFilter::Instance::clearFramesActiveStatus() {
	for (int i = 0; i < ThreadData::BUFFER_SIZE; i++) {
		detection.frames[i].active = false;
	}
}
~~~~
see more in the commit....