### PR TITLE
Resolve debug mask file path issue

### DIFF
--- a/face-mask-filter.cpp
+++ b/face-mask-filter.cpp
@@ -1984,7 +1984,13 @@ Mask::MaskData*
 Plugin::FaceMaskFilter::Instance::LoadMask(std::string filename) {
 
 	PLOG_INFO("Loading mask json '%s'...", filename.c_str());
-
+#ifndef PUBLIC_RELEASE
+	if (filename.find("/") == std::string::npos && filename.find("\\") == std::string::npos) {
+		std::string appdata;
+		appdata = getenv("APPDATA");
+		filename = appdata + "\\slobs-client\\FaceMasks\\" + filename;
+	}
+#endif
 	// new mask data
 	Mask::MaskData* mdat = new Mask::MaskData();
 


### PR DESCRIPTION
# Problem
In the development mode (Not release) there is no field for facemask location,
And when in the plugin widget the masks are set it fails to load masks.

# Solution
Change the mask path by adding pre-path: %appdata%/slobs-client/FaceMasks.