### PR TITLE
Clear the cache of faces and m_faces

### DIFF
--- a/face-mask-filter.cpp
+++ b/face-mask-filter.cpp
@@ -760,6 +760,9 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 		std::unique_lock<std::mutex> lock(detection.mutex);
 		detection.frameIndex = -1;
 		detection.facesIndex = -1;
+		// reset the detected faces
+		smllFaceDetector->ResetFaces();
+		faces.length = 0;
 		// make sure file loads still happen
 		checkForMaskUnloading();
 		// *** SKIP ***

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -1323,6 +1323,11 @@ namespace smll {
 		// unstage the surface and leave graphics context
 		gs_stagesurface_unmap(m_captureStage);
 	}
+
+	void FaceDetector::ResetFaces() {
+		m_faces.length = 0;
+		m_detectionTimeout = 0;
+	}
 	
 } // smll namespace
 

--- a/smll/FaceDetector.hpp
+++ b/smll/FaceDetector.hpp
@@ -59,6 +59,7 @@ public:
 	void DetectFaces(const ImageWrapper& detect, const OBSTexture& capture, DetectionResults& results);
 	void DetectLandmarks(const OBSTexture& capture, DetectionResults& results);
 	void DoPoseEstimation(DetectionResults& results);
+	void ResetFaces();
 
 	void MakeTriangulation(MorphData& morphData, DetectionResults& results, 
 		TriangulationResult& result);


### PR DESCRIPTION
This PR is the fix for the FaceMask loading at a previous location when the draw mask option is switched off and then switched on.