### PR TITLE
Add Unicode support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,7 @@ source_group("Mask\\Sources" FILES ${mask_SOURCES})
 
 # Compiler Configuration
 add_definitions(-D_CRT_SECURE_NO_WARNINGS) # Hide Microsofts insecurities
+add_definitions(-DUNICODE -D_UNICODE)      # Use Unicode Charset
 ## All Warnings, Extra Warnings, Pedantic
 if (MSVC)
 	if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")


### PR DESCRIPTION
## Problem
Facemask source won't load with Unicode symbols

## Solution
The plugin is compiled with `-D_UNICODE` and `-DUNICODE` character set flags
