### PR TITLE
Fix Thumbs Duplicate and Missing masks Bug

### DIFF
--- a/face-mask-filter.cpp
+++ b/face-mask-filter.cpp
@@ -147,8 +147,7 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 	alertTextTexture(nullptr), 
 	currentAlertLocation(LEFT_TOP),  alertTranslation(-35.0f), alertAspectRatio(1.15f),
 	alertElapsedTime(BIG_ASS_FLOAT), alertTriggered(false), alertShown(false), alertsLoaded(false),
-	demoModeOn(false), demoModeMaskJustChanged(false), demoModeMaskChanged(false), 
-	demoCurrentMask(0), demoModeInterval(0.0f), demoModeDelay(0.0f), demoModeElapsed(0.0f), 
+	demoModeOn(false), demoCurrentMask(0),
 	demoModeInDelay(false), demoModeGenPreviews(false),	demoModeSavingFrames(false), 
 	drawMask(true),	drawAlert(false), drawFaces(false), drawMorphTris(false), drawFDRect(false), 
 	filterPreviewMode(false), autoBGRemoval(false), cartoonMode(false), testingStage(nullptr) {
@@ -318,8 +317,6 @@ void Plugin::FaceMaskFilter::Instance::get_defaults(obs_data_t *data) {
 	obs_data_set_default_bool(data, P_DRAWCROPRECT, false);
 
 	obs_data_set_default_bool(data, P_DEMOMODEON, false);
-	obs_data_set_default_double(data, P_DEMOINTERVAL, 7.0f);
-	obs_data_set_default_double(data, P_DEMODELAY, 3.0f);
 
 #if !defined(PUBLIC_RELEASE)
 	// default advanced params
@@ -427,8 +424,6 @@ void Plugin::FaceMaskFilter::Instance::get_properties(obs_properties_t *props) {
 	// Demo mode
 	add_bool_property(props, P_DEMOMODEON);
 	add_text_property(props, P_DEMOFOLDER);
-	add_float_slider(props, P_DEMOINTERVAL, 1.0f, 60.0f, 1.0f);
-	add_float_slider(props, P_DEMODELAY, 1.0f, 60.0f, 1.0f);
 
 	add_bool_property(props, P_GENTHUMBS);
 
@@ -512,8 +507,6 @@ void Plugin::FaceMaskFilter::Instance::update(obs_data_t *data) {
 	// demo mode
 	demoModeOn = obs_data_get_bool(data, P_DEMOMODEON);
 	demoModeFolder = obs_data_get_string(data, P_DEMOFOLDER);
-	demoModeInterval = (float)obs_data_get_double(data, P_DEMOINTERVAL);
-	demoModeDelay = (float)obs_data_get_double(data, P_DEMODELAY);
 	demoModeGenPreviews = obs_data_get_bool(data, P_GENTHUMBS);
 
 	// update our param values
@@ -611,9 +604,6 @@ void Plugin::FaceMaskFilter::Instance::video_tick(float timeDelta) {
 	// ----- GET FACES FROM OTHER THREAD -----
 	updateFaces();
 
-	// demo mode stuff
-	demoModeUpdate(timeDelta);
-
 	// Lock mask datas mutex
 	std::unique_lock<std::mutex> masklock(maskDataMutex, std::try_to_lock);
 	if (!masklock.owns_lock()) {
@@ -651,9 +641,10 @@ void Plugin::FaceMaskFilter::Instance::video_tick(float timeDelta) {
 
 	// get the right mask data
 	Mask::MaskData* mdat = maskData.get();
-	if (demoModeOn && !demoModeInDelay) {
-		if (demoCurrentMask >= 0 && demoCurrentMask < demoMaskDatas.size())
+	if (demoModeOn) {
+		if (demoCurrentMask >= 0 && demoCurrentMask < demoMaskDatas.size()) {
 			mdat = demoMaskDatas[demoCurrentMask].get();
+		}
 	}
 
 	// Alert triggered?
@@ -891,12 +882,11 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 	}
 
 	// flags
-	bool genThumbs = mask_data && demoModeOn &&
-		demoModeMaskChanged && demoModeGenPreviews && demoModeSavingFrames;
+	bool genThumbs = mask_data && demoModeOn && demoModeGenPreviews && demoModeSavingFrames;
 
 	// render mask to texture
 	gs_texture* mask_tex = nullptr;
-	if (faces.length > 0 && !demoModeInDelay) {
+	if (faces.length > 0) {
 		// only render once per video tick
 		if (videoTicked) {
 
@@ -955,7 +945,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 						gs_matrix_identity();
 
 						// Draw the source video
-						if (mask_data && !demoModeInDelay) {
+						if (mask_data) {
 							triangulation.autoBGRemoval = autoBGRemoval;
 							triangulation.cartoonMode = cartoonMode;
 							mask_data->RenderMorphVideo(vidTex, baseWidth, baseHeight, triangulation);
@@ -1107,7 +1097,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 			!genThumbs)) {
 
 		// Draw the source video
-		if (mask_data && !demoModeInDelay) {
+		if (mask_data) {
 			triangulation.autoBGRemoval = autoBGRemoval;
 			triangulation.cartoonMode = cartoonMode;
 			mask_data->RenderMorphVideo(vidTex, baseWidth, baseHeight, triangulation);
@@ -1165,8 +1155,6 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 	// a good spot to unload mask data if we need to.
 	checkForMaskUnloading();
 
-	// 1 frame only
-	demoModeMaskJustChanged = false;
 	videoTicked = false;
 }
 
@@ -1189,32 +1177,11 @@ void Plugin::FaceMaskFilter::Instance::checkForMaskUnloading() {
 	}
 }
 
-
-void Plugin::FaceMaskFilter::Instance::demoModeUpdate(float timeDelta) {
-	// demo mode : switch masks/delay
-	if (demoModeOn && demoMaskDatas.size()) {
-		demoModeElapsed += timeDelta;
-		if (demoModeInDelay && (demoModeElapsed > demoModeDelay)) {
-			demoModeInDelay = false;
-			demoModeElapsed -= demoModeDelay;
-		}
-		else if (!demoModeInDelay && (demoModeElapsed > demoModeInterval)) {
-			demoCurrentMask = (demoCurrentMask + 1) % demoMaskDatas.size();
-			demoModeMaskChanged = true;
-			demoModeMaskJustChanged = true;
-			demoModeSavingFrames = false;
-			demoModeElapsed -= demoModeInterval;
-			demoModeInDelay = true;
-		}
-	}
-}
-
 void Plugin::FaceMaskFilter::Instance::demoModeRender(gs_texture* vidTex, gs_texture* maskTex, 
 	Mask::MaskData* mask_data) {
 
 	// generate previews?
-	if (demoModeOn && !demoModeInDelay && videoTicked &&
-		demoModeMaskChanged && demoModeGenPreviews) {
+	if (demoModeOn && videoTicked && demoModeGenPreviews && demoMaskDatas.size() > 0) {
 
 		// get frame color
 		if (!testingStage) {
@@ -1241,8 +1208,10 @@ void Plugin::FaceMaskFilter::Instance::demoModeRender(gs_texture* vidTex, gs_tex
 			else if (isRed) {
 				// done
 				WritePreviewFrames();
-				demoModeMaskChanged = false;
 				demoModeSavingFrames = false;
+				//increase mask number, change mask
+				demoCurrentMask = (demoCurrentMask + 1) % demoMaskDatas.size();
+				demoModeInDelay = false;
 			}
 			else {
 				PreviewFrame pf(maskTex, baseWidth, baseHeight);
@@ -1250,9 +1219,16 @@ void Plugin::FaceMaskFilter::Instance::demoModeRender(gs_texture* vidTex, gs_tex
 			}
 		}
 		else if (isRed) {
-			// ready to go
-			mask_data->Rewind();
-			demoModeSavingFrames = true;
+			if (demoModeInDelay) {
+				// ready to go
+				mask_data->Rewind();
+				demoModeSavingFrames = true;
+				demoModeInDelay = false;
+			}
+		}
+		else {
+			//wait one cycle
+			demoModeInDelay = true;
 		}
 	}
 }
@@ -1965,7 +1941,6 @@ void Plugin::FaceMaskFilter::Instance::LoadDemo() {
 		}
 	}
 	demoCurrentMask = 0;
-	demoModeMaskChanged = true;
 	demoModeSavingFrames = false;
 }
 

--- a/face-mask-filter.h
+++ b/face-mask-filter.h
@@ -204,20 +204,14 @@ namespace Plugin {
 
 			// demo mode
 			bool				demoModeOn;
-			bool				demoModeMaskJustChanged;
-			bool				demoModeMaskChanged;
 			std::string			demoModeFolder;
 			int					demoCurrentMask;
-			float				demoModeElapsed;
-			float				demoModeInterval;
-			float				demoModeDelay;
 			bool				demoModeInDelay;
 			bool				demoModeGenPreviews;
 			bool				demoModeSavingFrames;
 			std::vector<std::unique_ptr<Mask::MaskData>>	demoMaskDatas;
 			std::vector<std::string> demoMaskFilenames;
 
-			void demoModeUpdate(float timeDelta);
 			void demoModeRender(gs_texture* vidTex, 
 				gs_texture* maskTex, Mask::MaskData* mask_data);
 

--- a/mask.cpp
+++ b/mask.cpp
@@ -806,7 +806,7 @@ bool Mask::MaskData::RenderMorphVideo(gs_texture* vidtex, uint32_t width, uint32
 		AddResource(n, r);
 	}
 
-	if (aid->alpha > 0.0f && trires.vertexBuffer) {
+	if (m_morph && aid->alpha > 0.0f && trires.vertexBuffer) {
 		didMorph = true;
 		m_morph->RenderMorphVideo(vidtex, trires);
 	}

--- a/strings.h
+++ b/strings.h
@@ -38,8 +38,6 @@
 #define P_DRAWCROPRECT			"drawFDCropRect"
 #define P_DEMOMODEON			"demoMode"
 #define P_DEMOFOLDER			"demoFolder"
-#define P_DEMOINTERVAL			"demoInterval"
-#define P_DEMODELAY				"demoDelay"
 #define P_BGREMOVAL				"greenscreen"
 #define P_GENTHUMBS				"genpreviews"
 #define P_REWIND				"rewindanims"


### PR DESCRIPTION
#### Problem:
- Generating lots of thumbs makes duplicated masks and some marks are missing
- Demo Delay and Interval depends on the platform and doesn't work properly


#### Solution:
- Removed delay and interval and replaced with automated internal control solution