### PR TITLE
Fix Alpha fading of the mask

### DIFF
--- a/face-mask-filter.cpp
+++ b/face-mask-filter.cpp
@@ -865,7 +865,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 		if (alertElapsedTime > alertDuration)
 			maskAlpha = 0.0f;
 		else if (alertElapsedTime > t)
-			maskAlpha = Utils::hermite((alertElapsedTime - 1) / MASK_FADE_TIME, 1.0f, 0.0f);
+			maskAlpha = Utils::hermite((alertElapsedTime - t) / MASK_FADE_TIME, 1.0f, 0.0f);
 	}
 	if (drawMask)
 		maskAlpha = 1.0f;


### PR DESCRIPTION
### Problem
At the last moment of a face mask being played, the renderer seems alpha channel fading is not calculated correctly.

### Fix
Fixed with correcting expression.