### PR TITLE
Remove CorrelateAndCopyPosesFrom

### DIFF
--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -232,30 +232,6 @@ namespace smll {
 		}
 	}
 
-	void DetectionResults::CorrelateAndCopyPosesFrom(DetectionResults& other) {
-
-		DetectionResults& faces = *this;
-
-		// clear matched flags
-		for (int i = 0; i < other.length; i++) {
-			other[i].matched = false;
-		}
-		// match our faces to the other ones
-		for (int i = 0; i < faces.length; i++) {
-			// find closest
-			int closest = other.findClosest(faces[i]);
-
-			// copy pose
-			if (closest >= 0) {
-				faces[i].CopyPoseFrom(other[closest]);
-				other[closest].matched = true;
-			}
-			else {
-				faces[i].ResetPose();
-			}
-		}
-	}
-
 	int DetectionResults::findClosest(const smll::DetectionResult& result) {
 
 		DetectionResults& results = *this;

--- a/smll/DetectionResults.hpp
+++ b/smll/DetectionResults.hpp
@@ -136,7 +136,6 @@ namespace smll {
 	public:
 		DetectionResults();
 		void CorrelateAndUpdateFrom(DetectionResults& other);
-		void CorrelateAndCopyPosesFrom(DetectionResults& other);
 		int findClosest(const smll::DetectionResult& result);
 
 	private:


### PR DESCRIPTION
Removed the unused method from the DetectionResults. This branch is taken from latest `staging` and ready to merge.