### PR TITLE
Play Once mode

### DIFF
--- a/mask/mask-instance-data.h
+++ b/mask/mask-instance-data.h
@@ -110,7 +110,7 @@ namespace Mask {
 
 		inline void Push(std::size_t the_id) {
 			hash_combine(the_id);
-			m_stack.push_back(the_id);
+			m_stack.push_back(m_currentId);
 		}
 
 		inline void PushDirect(std::size_t the_id) {

--- a/mask/mask-resource-material.cpp
+++ b/mask/mask-resource-material.cpp
@@ -404,6 +404,7 @@ bool Mask::Resource::Material::Loop(Mask::Part* part, BonesList* bones) {
 		
 		// set up image params (image/sequence)
 		bool texmatset = false;
+		bool is_instance_visible = true;
 		for (auto kv : m_imageParameters) {
 			try {
 				auto el = m_effect->GetEffect()->GetParameterByName(kv.first);
@@ -429,6 +430,9 @@ bool Mask::Resource::Material::Loop(Mask::Part* part, BonesList* bones) {
 					texmatset = true;
 					if (effparm)
 						gs_effect_set_matrix4(effparm, &texmat);
+
+					// should we delay rendering?
+					is_instance_visible = seq->IsInstancePlaying();
 				}
 			}
 			catch (...) {
@@ -447,7 +451,7 @@ bool Mask::Resource::Material::Loop(Mask::Part* part, BonesList* bones) {
 			std::shared_ptr<AlphaInstanceData> aid =
 				m_parent->instanceDatas.GetData<AlphaInstanceData>
 				(AlphaInstanceDataId);
-			gs_effect_set_float(effparm, aid->alpha);
+			gs_effect_set_float(effparm, is_instance_visible ? aid->alpha : 0.0);
 		}
 
 		// get the technique

--- a/mask/mask-resource-sequence.cpp
+++ b/mask/mask-resource-sequence.cpp
@@ -169,6 +169,10 @@ void Mask::Resource::Sequence::Update(Mask::Part* part, float time) {
 				else if (IsRepeatMode()) {
 					instData->current = m_first;
 				}
+				else if (m_mode == Mask::Resource::Sequence::ONCE) {
+					instData->current = m_last;
+					instData->playback_ended = true;
+				}
 				else {
 					instData->current = m_last;
 				}
@@ -188,9 +192,10 @@ void Mask::Resource::Sequence::Update(Mask::Part* part, float time) {
 		}
 
 		// delay mode, and on first frame?
-		if (IsDelayMode() && pastFirst) {
+		if (IsDelayMode() && (pastFirst || !instData->playback_started)) {
 			// set delay
 			instData->delay = m_delay;
+			instData->playback_started = true;
 			instData->current = m_first;
 		}
 	}
@@ -208,6 +213,23 @@ void Mask::Resource::Sequence::Render(Mask::Part* part) {
 	m_image->Render(part);
 }
 
+
+bool Mask::Resource::Sequence::IsInstancePlaying() {
+	// get our instance data
+	m_parent->instanceDatas.Push(m_id);
+
+	// get our instance data
+	std::shared_ptr<SequenceInstanceData> instData =
+		m_parent->instanceDatas.GetData<SequenceInstanceData>();
+
+	bool is_playing = instData->delay == 0 || instData->current > 0;
+	bool not_ended = instData->playback_ended;
+
+	m_parent->instanceDatas.Pop();
+
+	return is_playing && !not_ended;
+
+}
 
 void Mask::Resource::Sequence::SetTextureMatrix(Mask::Part* part, matrix4* texmat) {
 	UNUSED_PARAMETER(part);

--- a/mask/mask-resource-sequence.h
+++ b/mask/mask-resource-sequence.h
@@ -30,12 +30,16 @@ namespace Mask {
 			int		delta;
 			float	elapsed;
 			float   delay;
+			bool	playback_started;
+			bool	playback_ended;
 			SequenceInstanceData() : current(-1), delta(1), 
-				elapsed(0.0f), delay(0.0f) {}
+				elapsed(0.0f), delay(0.0f), playback_started(false), playback_ended(false) {}
 
 			void Reset() override {
 				current = 0;
 				elapsed = 0.0f;
+				playback_started = false;
+				playback_ended = false;
 			}
 			void Reset(int first, int last) {
 				float a = (float)rand() / (float)RAND_MAX;
@@ -43,6 +47,8 @@ namespace Mask {
 				float min = (float)first;
 				current = (int)(a * (max - min) + min);
 				elapsed = 0.0f;
+				playback_started = false;
+				playback_ended = false;
 			}
 		};
 
@@ -57,6 +63,7 @@ namespace Mask {
 
 			std::shared_ptr<Image> GetImage() { return m_image; }
 			void SetTextureMatrix(Mask::Part* part, matrix4* texmat);
+			bool IsInstancePlaying();
 
 			enum Mode : uint32_t {
 				ONCE,
@@ -94,7 +101,8 @@ namespace Mask {
 			}
 			bool IsDelayMode() {
 				return (m_mode == Mask::Resource::Sequence::REPEAT_DELAY ||
-					m_mode == Mask::Resource::Sequence::BOUNCE_DELAY);
+					m_mode == Mask::Resource::Sequence::BOUNCE_DELAY ||
+					m_mode == Mask::Resource::Sequence::ONCE);
 			}
 			bool IsBounceMode() {
 				return (m_mode == Mask::Resource::Sequence::BOUNCE ||


### PR DESCRIPTION
## Overview
This PR will add support for playing sequences only once and at a certain time with a delay option.

## Changes

- Fix state handling issue for instance datas. `MaskInstanceDatas` push command was not saving the hashed version of id in the stack, ending up with a wrong stack after popping. This led to creating new instances for the same part.
- Add play once feature by setting alpha to zero, when delay has not reached zero, or the sequence frame has run out.


## Results
To test this feature, `mouthBeam_ver4.json` was adjusted by changing `energy fire` sequence playback mode to `once`, and setting delay to `5.0`. In the following video you can see the ring of energy appears after 5 seconds, and disappears again when the sequence ends.

![demo_play_once](https://user-images.githubusercontent.com/3115894/47687118-ea2c8480-db9b-11e8-8045-926946d9c2d2.gif)
