### PR TITLE
Fix Reflection Map Vector

### DIFF
--- a/data/effects/phong.effect
+++ b/data/effects/phong.effect
@@ -425,10 +425,9 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 
 	// reflection map trumps diffuse
 	if (reflectMap != 0) {
-		float3 r = reflect(normalize(-vpos), normal);
+		float3 r = -normalize(reflect(-vpos, normal));
 		float m = 2.0 * sqrt( pow( r.x, 2.0 ) + pow( r.y, 2.0 ) + pow( r.z + 1.0, 2.0 ) );
 		float2 vN = r.xy / m + 0.5;
-		vN.y = 1.0 - vN.y; // need to flip Y
 		
 		dffColor = reflectTex.Sample(reflectSampler, vN);
 	}


### PR DESCRIPTION
This will fix the reflection map vector being backwards.
![fix-reflection](https://user-images.githubusercontent.com/3115894/48447812-e1b67b00-e751-11e8-8dd9-3e49c7d942a3.png)
![globe](https://user-images.githubusercontent.com/3115894/48449004-a3bb5600-e755-11e8-8dad-af877cb12a44.png)

