### PR TITLE
Fix antialiasing blurring

### DIFF
--- a/data/effects/aa.effect
+++ b/data/effects/aa.effect
@@ -266,8 +266,8 @@ float4 fxaa(float2 uv) {
 	}
 
 	// Read the color at the new UV coordinates, and use it.
-	// return image.SampleLevel(def_sampler,final_uv,0);
-	return average(final_uv);
+	return image.SampleLevel(def_sampler,final_uv,0);
+	// return average(final_uv);
 
 }
 

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -825,7 +825,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 		antialiasing_method == FXAA_ANTI_ALIASING)
 		m_scale_rate = 1;
 	else
-		m_scale_rate = 2;
+		m_scale_rate = SSAA_UPSAMPLE_FACTOR;
 
 
 	// render mask to texture
@@ -1047,7 +1047,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 		while (gs_effect_loop(custom_effect, "Draw")) {
 			gs_effect_set_texture(gs_effect_get_param_by_name(custom_effect,
 				"image"), mask_tex);
-			gs_draw_sprite(mask_tex, 0, baseWidth*m_scale_rate, baseHeight*m_scale_rate);
+			gs_draw_sprite(mask_tex, 0, baseWidth, baseHeight);
 		}
 	}
 	
@@ -1351,8 +1351,8 @@ void Plugin::FaceMaskFilter::Instance::drawMaskData(Mask::MaskData*	_maskData,
 	gs_viewport_push();
 	gs_projection_push();
 
-	uint32_t w = baseWidth;
-	uint32_t h = baseHeight;
+	uint32_t w = baseWidth*m_scale_rate;
+	uint32_t h = baseHeight*m_scale_rate;
 
 	gs_set_viewport(0, 0, w, h);
 	gs_enable_depth_test(true);

--- a/plugin/face-mask-filter.h
+++ b/plugin/face-mask-filter.h
@@ -42,6 +42,8 @@ extern "C" {
 #pragma warning( pop )
 }
 
+#define SSAA_UPSAMPLE_FACTOR 2
+
 using namespace std;
 
 namespace Plugin {


### PR DESCRIPTION
This PR will fix antialiasing over-blurring that made high frequency features suffer.
The top image is w/o antialiasing, the bottom one has SSAA 2x.

![comapre-ssaa2x](https://user-images.githubusercontent.com/3115894/48726880-82d78280-ebe5-11e8-93b1-aa5070362df7.png)

Click the video to see the difference in full-size:
![ssaa2x](https://user-images.githubusercontent.com/3115894/48726566-a0581c80-ebe4-11e8-9104-5adf30af5353.gif)
