### PR TITLE
Disable antialiasing in the release version

### DIFF
--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -280,6 +280,8 @@ void Plugin::FaceMaskFilter::Instance::get_defaults(obs_data_t *data) {
 	obs_data_set_default_string(data, P_ALERT_OUTRO, kDefaultOutro);
 
 	bfree(defMaskFolder);
+	
+	obs_data_set_default_int(data, P_ANTI_ALIASING, NO_ANTI_ALIASING);
 
 	// ALERTS
 	obs_data_set_default_bool(data, P_ALERT_ACTIVATE, false);

--- a/plugin/face-mask-filter.h
+++ b/plugin/face-mask-filter.h
@@ -135,7 +135,7 @@ namespace Plugin {
 
 			gs_effect_t*		custom_effect = nullptr;
 			int					m_scale_rate = 1;
-			int					antialiasing_method = SSAA_ANTI_ALIASING;
+			int					antialiasing_method = NO_ANTI_ALIASING;
 
 			// Texture rendering & staging
 			gs_texrender_t*		sourceRenderTarget;


### PR DESCRIPTION
This PR sets the default for antialiasing to No Antialiasing in all build modes.