### PR TITLE
Fix Unicode Path Issue Crashing SLOBS

### DIFF
--- a/plugin/utils.cpp
+++ b/plugin/utils.cpp
@@ -51,8 +51,12 @@ namespace Utils {
 		::GetTempPath(256, dbuff);
 		::GetTempFileName(dbuff, nullptr, 0, tbuff);
 #ifdef UNICODE
+		std::wstring stbuff(tbuff);
+		// This is to keep the changes minimal
+		// TODO change return type to std::string
 		static char buff[256];
-		wcstombs(buff, (wchar_t*)tbuff, wcslen((wchar_t*)tbuff) + 1);
+		std::string str = ConvertWstringToString(stbuff);
+		strcpy(buff, str.c_str());
 #else
 		char* buff = tbuff;
 #endif

--- a/thirdparty/tinyobjloader/tiny_obj_loader.h
+++ b/thirdparty/tinyobjloader/tiny_obj_loader.h
@@ -47,6 +47,8 @@ THE SOFTWARE.
 #include <string>
 #include <vector>
 
+#include "plugin/utils.h"
+
 namespace tinyobj {
 
 // https://en.wikipedia.org/wiki/Wavefront_.obj_file says ...
@@ -1349,20 +1351,20 @@ bool MaterialFileReader::operator()(const std::string &matId,
                                     std::vector<material_t> *materials,
                                     std::map<std::string, int> *matMap,
                                     std::string *err) {
-  std::string filepath;
+  std::wstring filepath;
 
   if (!m_mtlBaseDir.empty()) {
-    filepath = std::string(m_mtlBaseDir) + matId;
+    filepath = Utils::ConvertStringToWstring(m_mtlBaseDir) + Utils::ConvertStringToWstring(matId);
   } else {
-    filepath = matId;
+    filepath = Utils::ConvertStringToWstring(matId);
   }
 
   std::ifstream matIStream(filepath.c_str());
   if (!matIStream) {
-    std::stringstream ss;
+    std::wstringstream ss;
     ss << "WARN: Material file [ " << filepath << " ] not found." << std::endl;
     if (err) {
-      (*err) += ss.str();
+      (*err) += Utils::ConvertWstringToString(ss.str());
     }
     return false;
   }
@@ -1415,7 +1417,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
   std::stringstream errss;
 
-  std::ifstream ifs(filename);
+  std::ifstream ifs(Utils::ConvertStringToWstring(filename));
   if (!ifs) {
     errss << "Cannot open file [" << filename << "]" << std::endl;
     if (err) {


### PR DESCRIPTION
This PR will fix the issue with opening obj files using tiny obj library. Previously, if a user had installed SLOBS in a path with unicode characters, the plugin would crash.
The main cause of the problem is using `ifstream` with `std::string`. This PR converts path strings in tiny obj to utf-16 wstring to avoid that issue.