### PR TITLE
Fix random start for sequences

### DIFF
--- a/mask/mask-resource-sequence.h
+++ b/mask/mask-resource-sequence.h
@@ -36,7 +36,7 @@ namespace Mask {
 				elapsed(0.0f), delay(0.0f), playback_started(false), playback_ended(false) {}
 
 			void Reset() override {
-				current = 0;
+				current = -1;
 				elapsed = 0.0f;
 				playback_started = false;
 				playback_ended = false;


### PR DESCRIPTION
This PR fixes issue with sequence textures not playing correctly when using random start.

## Issues
In short, two issues were fixed:

- When triggering a mask for the second time, the mask data was being reset by calling its reset function, however random start sequences have a different overloaded method for handling that.
- Frames were not advanced correctly. If between updates, we had to advance 7 frames in a 5-frame sequence, we would just end up at frame 5, without accounting for cycling through the next round of play. This happened both for bouncing and repeating animations.

## Affected Masks
This PR potentially affects every looping sequence animation, either bouncing or repeating. Examples include glasses slabs, toast hot and party santa.