### PR TITLE
Add FBX InheritRrs support

### DIFF
--- a/mask/mask.h
+++ b/mask/mask.h
@@ -62,6 +62,11 @@ namespace Mask {
 		std::vector<std::shared_ptr<Resource::IBase>> resources;
 		std::shared_ptr<Part> parent;
 		std::size_t hash_id;
+		// Name of part, used for local transform chain detection
+		std::string name;
+		// Is this part a local transformation for another part?
+		// local_to will keep the name of that part
+		std::string local_to;
 		vec3 position, scale, rotation;
 		quat qrotation;
 
@@ -70,6 +75,12 @@ namespace Mask {
 		bool localdirty;
 		bool dirty;
 		bool isquat;
+		// FBX Inherit Type
+		// RrSs: Apply parent scaling after child scaling.
+		// RSrs: What logically should happen: First parent rotation and scaling, and then child's.
+		// Rrs:  Parent scaling is ignored.
+		enum InheritType { Inherit_RrSs = 0, Inherit_RSrs, Inherit_Rrs };
+		InheritType inherit_type = Inherit_RSrs;
 	};
 
 	class SortedDrawObject {
@@ -158,7 +169,7 @@ namespace Mask {
 
 	private:
 		std::shared_ptr<Part> LoadPart(std::string name, obs_data_t* data);
-		static void PartCalcMatrix(std::shared_ptr<Mask::Part> part);
+		static void PartCalcMatrix(Part *part);
 
 		struct {
 			std::string name;

--- a/mask/mask.h
+++ b/mask/mask.h
@@ -170,6 +170,7 @@ namespace Mask {
 	private:
 		std::shared_ptr<Part> LoadPart(std::string name, obs_data_t* data);
 		static void PartCalcMatrix(Part *part);
+		static void Decompose(const matrix4 *src, vec3 *s, matrix4 *R, vec3 *t);
 
 		struct {
 			std::string name;


### PR DESCRIPTION
## Overview
FBX file format supports three different types of transformation inheritance:
- **eInheritRrSs:** Scaling of parent is applied in the child world after the local child rotation.
- **eInheritRSrs:** Scaling of parent is applied in the parent world.
- **eInheritRrs:** Scaling of parent does not affect the scaling of children.

This PR will add support for the third mode of inheritance which is used by joint hierarchy in Maya.

## TL;DR
This PR will not break anything, however to make use of the added feature, the PR for art tool should be also merged.

## Problem
The natural way to apply transformations is the second mode, eInheritRSrs, which is the default for most of the time. In one case, Maya breaks this default mode and that's for joint hierarchy or bones.

These other modes of inheritance are not supported by most of the fbx importers, even Autodesk 3dsmax doesn't support it, see [here](http://download.autodesk.com/us/fbx/fbx_maya_online/files/WS73099cc142f48755-3d114b751181c40f14b1283.htm). Facebook FBX2glTF converter has faced the same [issue](https://github.com/facebookincubator/FBX2glTF/issues/27) as well, which currently uses a [hack](https://github.com/facebookincubator/FBX2glTF/blob/d38ccd935f855a777082e4d9164d662381e4faf5/src/fbx/Fbx2Raw.cpp#L598) that only works with joints having identity scale. Unity didn't support this, and recently added support for it, but it has its limitations, [here](https://answers.unity.com/questions/1413998/scale-compensate-supported-or-not-supported.html) and [here](https://docs.unity3d.com/Manual/HOWTO-ImportObjectsFrom3DApps.html).

Overall, the issue is these other modes of inheritance may help the modeler, but are not natural and are somehow ambiguous in a transformation hierarchy, and require lots of unnecessary calculations to support them fully, or using hacks to make it work in some cases.

## Solution
To add support for this inheritance, there are 3 different places that needed modification.

1. **FBX Converter:**
   - Extract inherit types
   - Extract Local nodes hierarchy. Previously, all the transformations were chained together and we had no information if a node is a local transformation.
   - Create a backward compatible change in JSON spec:
      a. If an object has an inherit type which is not the default RSrs mode, save it in the node.
      b. For all the local nodes, add a `local-to` property which holds the name of the node which it is a local transformation for.
```javascript
"object1": {
      ...
     "inherit-type": 2
},
"object1_local_rot": {
      ...
     "local-to": "object1"
}
```

This way we can track which nodes in the hierarchy are local. These two properties are optional and dropping them, would just revert to the default calculation and hence a backward-compatible change.
These changes are applied to the converter are ready to merged in a separate PR.

 2. **Renderer:**
    - Previously, all the nodes in the hierarchy were multiplied to create the final global transformation.
    - To support the Rrs mode, we have to separate all the local nodes from the rest, and then only keep the scaling of the local node.
    - Should only do this if the inherit type is not the default RSrs mode.
    - To compensate scaling, instead of decomposing the whole matrix, only get the scale from the global matrix, inverse it, and inject it **in between** the local and the global matrices (more info in comments on the code):
```python
	Parent_Matrix = T * R * S
	Local_Matrix   = inv_S * (t * r * s)

 	Global_Matrix = Parent_Matrix * Local_Matrix
	Global_Matrix = (T * R * S) * (inv_S * t * r * s)
	Global_Matrix = (T * R) * (S * inv_S) * (t * r * s)
	Global_Matrix = (T * R) * (t * r * s)
```

## Migration

Merging this PR in itself is safe, as it should work the same for the old masks. However, to create masks that use the feature added in PR, a new version of FBX converter should be used. To enable safe migration, without breaking current workflow with possible issues in the new converter, a new option is added in the art tool to only use the new converter if the `BUILD BETA` button is pressed. This way, in case of issues, the old converter is still usable as before, until the new version gets stable.
![build_beta_mode_pub](https://user-images.githubusercontent.com/3115894/49910006-fa3fb100-fe35-11e8-8538-4622c5762333.png)

## Known Limitations

The eInheritRrSs mode support is not added, as it's not used by default in Maya or 3dsmax, so currently it's not worth the time/computation cost it needs. We'll have the data in our json files, and in case that becomes necessary, we can add that in a separate PR.

## Results
![chicken-compare](https://user-images.githubusercontent.com/3115894/49910380-5bb44f80-fe37-11e8-9f54-9402ecd6b15b.png)
