### PR TITLE
Fix recorder missing frames

### DIFF
--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -1169,7 +1169,11 @@ void Plugin::FaceMaskFilter::Instance::demoModeRender(gs_texture* vidTex, gs_tex
 				demoModeInDelay = false;
 			}
 			else {
-				PreviewFrame pf(maskTex, baseWidth, baseHeight);
+				gs_texture* preview_tex = maskTex;
+				if (faces.length == 0) {
+					preview_tex = vidTex;
+				}
+				PreviewFrame pf(preview_tex, baseWidth, baseHeight);
 				previewFrames.emplace_back(pf);
 			}
 		}


### PR DESCRIPTION
Fix Recorder: When a face wasn't detectable, frames were missing