### PR TITLE
EPnP pose solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ ipch
 x64
 .vs
 .mayaSwatches
+
+# Apps specific ignore
+output/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build
+build
 /build32
 /build64
 /#Build

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -1129,9 +1129,10 @@ namespace smll {
 			cv::solvePnP(model_points, image_points,
 				GetCVCamMatrix(), GetCVDistCoeffs(),
 				rotation, translation,
-				m_poses[i].PoseValid());
+				m_poses[i].PoseValid(),
+				cv::SOLVEPNP_EPNP);
 
-			// sometimes we get crap
+			// TODO: Check if we still get wrong results.
 			if (translation.at<double>(2, 0) > 1000.0 ||
 				translation.at<double>(2, 0) < -1000.0) {
 				resultsBad = true;
@@ -1139,7 +1140,8 @@ namespace smll {
 				break;
 			}
 
-			// check error again, still bad, use previous pose
+			// TODO: If possible, remove these sanity checks
+			// NOTE: If no pose is generated, use previous pose.
 			if (m_poses[i].PoseValid() &&
 				ReprojectionError(model_points, image_points, rotation, translation) > threshold) {
 				// reset pose


### PR DESCRIPTION
Replaced the existing OpenCV's default pose solver with Lepetit et al. EPnP Pose Solver. Reduces unnecessary flips when we have sudden (or) jerky movements. 