### PR TITLE
Code restructure - DetectionResults

### DIFF
--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -259,10 +259,6 @@ namespace smll {
 		pose.CopyPoseFrom(r.pose);
 	}
 
-	bool DetectionResult::PoseValid() {
-		return pose.PoseValid();
-	}
-
 	void DetectionResult::ResetPose() {
 		pose.ResetPose();
 	}

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -259,10 +259,6 @@ namespace smll {
 		pose.CopyPoseFrom(r.pose);
 	}
 
-	void DetectionResult::ResetPose() {
-		pose.ResetPose();
-	}
-
 	void DetectionResult::InitStartPose() {
 		if (!initedStartPose) {
 			startPose.rotation[0] = 0.0;

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -266,7 +266,7 @@ namespace smll {
 	void DetectionResult::InitStartPose() {
 		if (!initedStartPose) {
 			startPose.rotation[0] = 0.0;
-			startPose.rotation[1] = 0.0;
+			startPose.rotation[1] = 1.0;
 			startPose.rotation[2] = 0.0;
 			startPose.rotation[3] = 0.0;
 			startPose.translation[0] = 0.0;

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -211,7 +211,7 @@ namespace smll {
 		nStates = 18;
 		nMeasurements = 6;
 		nInputs = 0;
-		dt = 0.125;
+		dt = 0.125; // TODO: Change this as per the FPS of tracker.
 	}
 
 	DetectionResult::~DetectionResult() {

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -67,16 +67,9 @@ namespace smll {
 	}
 
 	cv::Mat ThreeDPose::GetCVTranslation() const {
-		cv::Mat m = cv::Mat::zeros(3, 1, CV_64F);
-		cv::Mat m1 = (cv::Mat_<double>(3, 1) << translation[0],
-											    translation[1],
-											    translation[2]);
-		m.at<double>(0, 0) = translation[0];
-		m.at<double>(1, 0) = translation[1];
-		m.at<double>(2, 0) = translation[2];
-		cv::Mat diff = m != m1;
-		bool eq = cv::countNonZero(diff) == 0;
-		blog(LOG_DEBUG, "Check Mat initialization = %d\n", eq);
+		cv::Mat m = (cv::Mat_<double>(3, 1) << translation[0],
+											   translation[1],
+											   translation[2]);
 		return m;
 	}
 

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -68,9 +68,15 @@ namespace smll {
 
 	cv::Mat ThreeDPose::GetCVTranslation() const {
 		cv::Mat m = cv::Mat::zeros(3, 1, CV_64F);
+		cv::Mat m1 = (cv::Mat_<double>(3, 1) << translation[0],
+											    translation[1],
+											    translation[2]);
 		m.at<double>(0, 0) = translation[0];
 		m.at<double>(1, 0) = translation[1];
 		m.at<double>(2, 0) = translation[2];
+		cv::Mat diff = m != m1;
+		bool eq = cv::countNonZero(diff) == 0;
+		blog(LOG_DEBUG, "Check Mat initialization = %d\n", eq);
 		return m;
 	}
 

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -59,10 +59,9 @@ namespace smll {
 	}
 
 	cv::Mat ThreeDPose::GetCVRotation() const {
-		cv::Mat m = cv::Mat::zeros(3, 1, CV_64F);
-		m.at<double>(0, 0) = rotation[0] * rotation[3];
-		m.at<double>(1, 0) = rotation[1] * rotation[3];
-		m.at<double>(2, 0) = rotation[2] * rotation[3];
+		cv::Mat m = (cv::Mat_<double>(3, 1) << rotation[0] * rotation[3],
+											   rotation[1] * rotation[3],
+											   rotation[2] * rotation[3]);
 		return m;
 	}
 

--- a/smll/DetectionResults.cpp
+++ b/smll/DetectionResults.cpp
@@ -29,50 +29,6 @@
 
 namespace smll {
 
-	static void CheckForPoseFlip(double* r, double* t) {
-
-		// check for pose flip
-		if (t[2] < 0.0)
-		{
-			//blog(LOG_DEBUG, "***** POSE FLIP *****");
-
-			// flip translation
-			t[0] = -t[0];
-			t[1] = -t[1];
-			t[2] = -t[2];
-
-			// flip rotation
-			// this is odd, but works...
-
-			// flip z and the angle
-			r[0] = r[0];
-			r[1] = r[1];
-			r[2] = -r[2];
-			r[3] = -r[3];
-
-			// rotate 180 around z
-			// use Rodrigues formula, simplified for rotation around Z
-			//
-			double cos1 = cos(r[3] / 2.0);
-			double sin1 = sin(r[3] / 2.0);
-			double cos2 = cos(M_PI / 2.0);
-			double sin2 = sin(M_PI / 2.0);
-
-			double a = acos(cos1 * cos2 - sin1 * sin2 * r[2]) * 2.0;
-			double x = sin1 * cos2 * r[0] + sin1 * sin2 * r[1];
-			double y = sin1 * cos2 * r[1] + sin1 * sin2 * r[0];
-			double z = sin1 * cos2 * r[2] + cos1 * sin2;
-
-			double sina = sin(a / 2.0);
-			if (sina < 0.0001)
-				sina = 1.0;
-			r[0] = x / sina;
-			r[1] = y / sina;
-			r[2] = z / sina;
-			r[3] = a;
-		}
-	}
-
 	ThreeDPose::ThreeDPose() {
 		ResetPose();
 	}
@@ -100,8 +56,6 @@ namespace smll {
 		translation[0] = cvTrs.at<double>(0, 0);
 		translation[1] = cvTrs.at<double>(1, 0);
 		translation[2] = cvTrs.at<double>(2, 0);
-
-		CheckForPoseFlip(rotation, translation);
 	}
 
 	cv::Mat ThreeDPose::GetCVRotation() const {
@@ -270,7 +224,6 @@ namespace smll {
 		for (int i = 0; i < NUM_FACIAL_LANDMARKS; i++) {
 			landmarks68[i] = r.landmarks68[i];
 		}
-		CheckForPoseFlip(pose.rotation, pose.translation);
 
 		kalmanFilterInitialized = false;
 		initedStartPose = false;
@@ -339,8 +292,6 @@ namespace smll {
 		double ntx[3] = { r.pose.translation[0], r.pose.translation[1], r.pose.translation[2] };
 		double nrot[4] = { r.pose.rotation[0], r.pose.rotation[1], r.pose.rotation[2], r.pose.rotation[3] };
 		dlib::rectangle bnd = r.bounds;
-
-		CheckForPoseFlip(nrot, ntx);
 
 		// kalman filtering enabled?
 		if (Config::singleton().get_bool(CONFIG_BOOL_KALMAN_ENABLE)) {

--- a/smll/DetectionResults.hpp
+++ b/smll/DetectionResults.hpp
@@ -90,7 +90,6 @@ namespace smll {
 		cv::Mat GetCVTranslation() const;
 
 		void CopyPoseFrom(const DetectionResult& r);
-		void ResetPose();
 		void InitStartPose();
 		void UpdateResultsFrom(const DetectionResult& r);
 

--- a/smll/DetectionResults.hpp
+++ b/smll/DetectionResults.hpp
@@ -92,7 +92,6 @@ namespace smll {
 		void CopyPoseFrom(const DetectionResult& r);
 		void ResetPose();
 		void InitStartPose();
-		bool PoseValid();
 		void UpdateResultsFrom(const DetectionResult& r);
 
 		double DistanceTo(const DetectionResult& r) const;

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -1019,10 +1019,6 @@ namespace smll {
         
     void FaceDetector::StartObjectTracking() {
 
-		// TODO: Complete full OpenCV 4.0.0 integration
-		//		Debug and Release and necessary dll's
-		//		Change the Face Data Structure
-		//		Log everything and then peace!
 		// get crop info from config and track image dimensions
 		CropInfo cropInfo = GetCropInfo();
 

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -835,9 +835,7 @@ namespace smll {
 				triangles[TriangulationResult::IDXBUFF_HULL].push_back(i1);
 				triangles[TriangulationResult::IDXBUFF_HULL].push_back(i2);
 			}
-			else /*if ((b0 & bgmask).any() ||
-				(b1 & bgmask).any() ||
-				(b2 & bgmask).any())*/ { 
+			else { 
 				triangles[TriangulationResult::IDXBUFF_BACKGROUND].push_back(i0);
 				triangles[TriangulationResult::IDXBUFF_BACKGROUND].push_back(i1);
 				triangles[TriangulationResult::IDXBUFF_BACKGROUND].push_back(i2);

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -442,7 +442,7 @@ namespace smll {
 		}
 		case VIDEO_FORMAT_UYVY:
 		{
-			img_width = frame->width / 2;
+			img_width = frame->width;
 			img_height = frame->height;
 			cv::Mat img(img_height, img_width, CV_8UC2, frame->data[0], int(frame->linesize[0]));
 			cv::cvtColor(img, grayImage, cv::COLOR_YUV2GRAY_UYVY);

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -418,7 +418,7 @@ namespace smll {
 		MakeAreaIndices(result, triangleList);
 	}
 
-	cv::Mat FaceDetector::ConvertFrameToGrayMat(obs_source_frame* frame) {
+	void FaceDetector::ConvertFrameToGrayMat(obs_source_frame* frame) {
 		int img_width, img_height;
 
 		switch (frame->format) {
@@ -495,8 +495,6 @@ namespace smll {
 		if (frame->flip) {
 			cv::flip(grayImage, grayImage, 0);
 		}
-
-		return grayImage;
 	}
 
 

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -648,18 +648,6 @@ namespace smll {
 		const cv::Mat& rot = face.GetCVRotation();
 		cv::Mat trx = face.GetCVTranslation();
 
-		/*
-		blog(LOG_DEBUG, "HEADPOINTS-----------------------");
-		blog(LOG_DEBUG, " trans: %5.2f, %5.2f, %5.2f",
-			(float)trx.at<double>(0, 0),
-			(float)trx.at<double>(1, 0),
-			(float)trx.at<double>(2, 0));
-		blog(LOG_DEBUG, "   rot: %5.2f, %5.2f, %5.2f",
-			(float)rot.at<double>(0, 0),
-			(float)rot.at<double>(1, 0),
-			(float)rot.at<double>(2, 0));
-			*/
-
 		std::vector<cv::Point2f> projheadpoints;
 		cv::projectPoints(headpoints, rot, trx, GetCVCamMatrix(), GetCVDistCoeffs(), projheadpoints);
 

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -485,9 +485,9 @@ namespace smll {
 			// TODO check if this works
 			img_width = frame->width;
 			img_height = frame->height;
-			cv::Mat img(img_height, img_width, CV_8UC4, frame->data[0], int(frame->linesize[0]));
+			cv::Mat img(img_height, img_width, CV_8UC3, frame->data[0], int(frame->linesize[0]));
 			cv::cvtColor(img, img, cv::COLOR_YCrCb2BGR);
-			cv::cvtColor(img, grayImage, cv::COLOR_RGB2GRAY);
+			cv::cvtColor(img, grayImage, cv::COLOR_BGR2GRAY);
 			break;
 		}
 		}

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -1098,9 +1098,6 @@ namespace smll {
 	void FaceDetector::DoPoseEstimation(DetectionResults& results)
 	{
 		// Build a set of model points to use for solving 3D pose
-		// NOTE: The keypoints sould be selected w.r.t stability
-		// TODO: Reduce Keypoints, change pose solver,
-		//       change per-frame pose to temporal pose
 		std::vector<int> model_indices;
 		model_indices.push_back(LEFT_OUTER_EYE_CORNER);
 		model_indices.push_back(RIGHT_OUTER_EYE_CORNER);

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -444,7 +444,7 @@ namespace smll {
 		{
 			img_width = frame->width / 2;
 			img_height = frame->height;
-			cv::Mat img(img_height, img_width, CV_8UC4, frame->data[0], int(frame->linesize[0]));
+			cv::Mat img(img_height, img_width, CV_8UC2, frame->data[0], int(frame->linesize[0]));
 			cv::cvtColor(img, grayImage, cv::COLOR_YUV2GRAY_UYVY);
 			break;
 		}

--- a/smll/FaceDetector.hpp
+++ b/smll/FaceDetector.hpp
@@ -70,11 +70,9 @@ public:
 		TriangulationResult& result);
 
 	int CaptureWidth() const {
-		//return m_capture.width;
 		return grayImage.cols;
 	}
 	int CaptureHeight() const {
-		//return m_capture.height;
 		return grayImage.rows;
 	}
 

--- a/smll/FaceDetector.hpp
+++ b/smll/FaceDetector.hpp
@@ -60,7 +60,7 @@ public:
 
 	FaceDetector();
 
-	cv::Mat ConvertFrameToGrayMat(obs_source_frame* frame);
+	void ConvertFrameToGrayMat(obs_source_frame* frame);
 	void DetectFaces(struct obs_source_frame * frame, int w, int h, DetectionResults& results);
 	void DetectLandmarks(DetectionResults& results);
 	void DoPoseEstimation(DetectionResults& results);


### PR DESCRIPTION
This PR deals with restructuring portions of code from `DetectionResults.*pp` files which include removing unused code, removing buggy pose flip check, single line Mat initialization for {R,t} get methods, and removing `DetectionResults::ResetPose` and `DetectionResults::PoseValid` functions as they are never referenced and we are currently using `ThreeDPose::ResetPose` and `ThreeDPose::PoseValid`.