### PR TITLE
Bug - CPU Frame for Webcam YUY2 Format

### DIFF
--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -434,9 +434,9 @@ namespace smll {
 		case VIDEO_FORMAT_YVYU:
 		case VIDEO_FORMAT_YUY2:
 		{
-			img_width = frame->width / 2;
+			img_width = frame->width;
 			img_height = frame->height;
-			cv::Mat img(img_height, img_width, CV_8UC4, frame->data[0], int(frame->linesize[0]));
+			cv::Mat img(img_height, img_width, CV_8UC2, frame->data[0], int(frame->linesize[0]));
 			cv::cvtColor(img, grayImage, cv::COLOR_YUV2GRAY_YUY2);
 			break;
 		}


### PR DESCRIPTION
This is a fix for the bug in the current facemask-plugin `staging` branch found when testing on Webcam video frames with YUY2 format. YUY2 is a compact representation of RGB pixel format. When a typical RGB pixel holds 24 bit information per pixel and RGBA holds 32 bit information per pixel, YUY2 holds 16 bit information per pixel. This representation usually helps in low throughput by representing the color space in 4 bits each in UV domain and luminance Y in 8 bits. For more information - http://www.fourcc.org/yuv.php#YUY2

Please note that our current code works well on offline videos. Webcams which give YUY2 frames will start working with this PR. Other formats need to be tested as well.

