### PR TITLE
Fix Light Attenuation in Phong Shader

### DIFF
--- a/data/effects/phong.effect
+++ b/data/effects/phong.effect
@@ -227,7 +227,7 @@ float  lightAngle) {
 			
 		// point and spot lights have attenuation
 		if (lightType == 2 || lightType == 3) {
-			float d = length(lightV) / 100.0;
+			float d = length(lightPosition - vpos) / 100.0;
 			float attenuation = 1.0 / 
 				(lightAttenuation.x + 
 				 (lightAttenuation.y * d) +
@@ -240,7 +240,7 @@ float  lightAngle) {
 				float cosAngle = dot( lightDir, -lightV );
 				attenuation *= smoothstep( minCos, maxCos, cosAngle ); 
 			}
-			lightColor *= attenuation;
+			lightColor *= saturate(attenuation);
 		}
 		
 		outColor += lightColor;


### PR DESCRIPTION
## Overview
This PR will fix light attenuation calculation in Phong Shader. The correct implementation should decay light intensity based on distance, and also saturate the resulting attenuation to conserve energy. Previously, the attenuated light could even become brighter than its full intensity, and was based on the light view direction, rather than light distance from a point.

## Impact
The changes will only affect point lights and spot lights. Directional lights are not affected. Tested the changes with several masks, and found no issues.