### PR TITLE
Remove GetCropInfo

### DIFF
--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -150,7 +150,6 @@ namespace smll {
 		}
 	}
 	void FaceDetector::computeDifference(DetectionResults& results) {
-		CropInfo cropInfo = GetCropInfo();
 		float scale = (float) grayImage.rows / resizeHeight ;
 		if (!isPrevInit ) {
 			isPrevInit = true;
@@ -231,8 +230,6 @@ namespace smll {
 		}
 		SetCropInfo(results);
 		// Do image cropping and cv::Mat initialization in single shot
-		CropInfo cropInfo = GetCropInfo();
-		
 		cv::Mat cropped = grayImage(cv::Rect(cropInfo.offsetX, cropInfo.offsetY, cropInfo.width, cropInfo.height));
 		currentImage = cropped.clone();
 	}
@@ -989,10 +986,6 @@ namespace smll {
 		}
 	}
 
-	FaceDetector::CropInfo FaceDetector::GetCropInfo() {
-		return cropInfo;
-	}
-
 	void FaceDetector::SetCropInfo(DetectionResults& results) {
 		int ww = results.motionRect.right() - results.motionRect.left();
 		int hh = results.motionRect.bottom() - results.motionRect.top();
@@ -1009,8 +1002,6 @@ namespace smll {
 
    void FaceDetector::DoFaceDetection() {
 
-		// get cropping info from config and detect image dimensions
-		CropInfo cropInfo = GetCropInfo();
 		// need to scale back
 		float scale = (float)grayImage.rows / resizeHeight;
 		cv::Mat detectionImg;

--- a/smll/FaceDetector.hpp
+++ b/smll/FaceDetector.hpp
@@ -131,7 +131,6 @@ private:
 		}
 	};
 	CropInfo    cropInfo;
-	CropInfo	GetCropInfo();
 	void		SetCropInfo(DetectionResults& results);
 	// Current Image
 	cv::Mat grayImage;


### PR DESCRIPTION
This method is removed because we are already using a global variable cropInfo for cropping the ROI from image and no other methods outside the class actually require this information.