### PR TITLE
Speed up mask loading

### DIFF
--- a/data/effects/aa.effect
+++ b/data/effects/aa.effect
@@ -3,41 +3,8 @@
 // Author: Kamyar Allahverdi
 // Date: October 23, 2018
 //
-// This FXAA implementation is a modified version of FXAA 3.11
-// The full license for NVIDIA FXAA 3.11 is provided here.
-//
-// Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-//  * Neither the name of NVIDIA CORPORATION nor the names of its
-//    contributors may be used to endorse or promote products derived
-//    from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-//----------------------------------------------------------------------------------
 
 uniform float4x4 ViewProj;
-uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 uniform texture2d image;
 
 uniform float inv_width;
@@ -47,11 +14,7 @@ uniform int antialiasing_method;
 
 #define NO_ANTI_ALIASING 0
 #define SSAA 1
-#define FXAA 2
 
-#define EDGE_THRESHOLD_MIN 0.0312
-#define EDGE_THRESHOLD_MAX 0.063
-#define SUBPIXEL_QUALITY 1
 
 sampler_state def_sampler {
 	Filter   = LINEAR;
@@ -72,206 +35,6 @@ VertInOut VSDefault(VertInOut vert_in)
 	return vert_out;
 }
 
-// FXAA
-float rgb2luma(float3 color){
-	// to improve results, we can render luminance in a previous pass
-	// here we use green as fast replacement for luminance
-	// if we are not concerned about speed we can use the following formula:
-    // return dot(color, float3(0.2126729,  0.7151522, 0.0721750));
-    return color.g;
-}
-
-float QUALITY(int index) {
-	if(index == 0)
-		return 1.0;
-	else if(index == 1)
-		return 1.5;
-	else if(index > 1 && index < 9)
-		return 2;
-	else
-		return 4;
-}
-
-float4 fxaa(float2 uv) {
-	float4 color_center = image.Sample(def_sampler, uv);
-
-	// Luma at the current fragment
-	float luma_center = rgb2luma(color_center.rgb);
-
-	// Luma at the four direct neighbours of the current fragment.
-	float luma_down = rgb2luma(image.Sample(def_sampler,uv,int2(0,-1)).rgb);
-	float luma_up = rgb2luma(image.Sample(def_sampler,uv,int2(0,1)).rgb);
-	float luma_left = rgb2luma(image.Sample(def_sampler,uv,int2(-1,0)).rgb);
-	float luma_right = rgb2luma(image.Sample(def_sampler,uv,int2(1,0)).rgb);
-
-	// Find the maximum and minimum luma around the current fragment.
-	float luma_min = min(luma_center,min(min(luma_down,luma_up),min(luma_left,luma_right)));
-	float luma_max = max(luma_center,max(max(luma_down,luma_up),max(luma_left,luma_right)));
-
-	float luma_contrast = luma_max - luma_min;
-	
-	// ignore all the pixels that don't have a high contrast around them
-	if(luma_contrast < max(EDGE_THRESHOLD_MIN,luma_max*EDGE_THRESHOLD_MAX)){
-		return color_center;
-	}
-	
-	float luma_down_left = rgb2luma(image.Sample(def_sampler,uv,int2(-1,-1)).rgb);
-	float luma_up_left = rgb2luma(image.Sample(def_sampler,uv,int2(-1,1)).rgb);
-	float luma_up_right = rgb2luma(image.Sample(def_sampler,uv,int2(1,1)).rgb);
-	float luma_down_right = rgb2luma(image.Sample(def_sampler,uv,int2(1,-1)).rgb);
-
-	// Combine the four edges lumas (using intermediary variables for future computations with the same values).
-	float luma_down_up = luma_down + luma_up;
-	float luma_left_right = luma_left + luma_right;
-
-	// Same for corners
-	float luma_left_corners = luma_down_left + luma_up_left;
-	float luma_down_corners = luma_down_left + luma_down_right;
-	float luma_right_corners = luma_down_right + luma_up_right;
-	float luma_up_corners = luma_up_right + luma_up_left;
-
-	// Compute an estimation of the gradient along the horizontal and vertical axis.
-	float edge_horizontal =  abs(-2.0 * luma_left + luma_left_corners)  + abs(-2.0 * luma_center + luma_down_up ) * 2.0    + abs(-2.0 * luma_right + luma_right_corners);
-	float edge_vertical =    abs(-2.0 * luma_up + luma_up_corners)      + abs(-2.0 * luma_center + luma_left_right) * 2.0  + abs(-2.0 * luma_down + luma_down_corners);
-
-	// Is the local edge horizontal or vertical ?
-	bool is_horizontal = (edge_horizontal >= edge_vertical);
-
-	// Select the two neighboring texels lumas in the opposite direction to the local edge.
-	float luma1 = is_horizontal ? luma_down : luma_left;
-	float luma2 = is_horizontal ? luma_up : luma_right;
-	// Compute gradients in this direction.
-	float gradient1 = luma1 - luma_center;
-	float gradient2 = luma2 - luma_center;
-
-	// Which direction is the steepest ?
-	bool is_1_steepest = abs(gradient1) >= abs(gradient2);
-
-	// Gradient in the corresponding direction, normalized.
-	float gradient_scaled = 0.25*max(abs(gradient1),abs(gradient2));
-
-	// Choose the step size (one pixel) according to the edge direction.
-	float step_length = is_horizontal ? inv_height : inv_width;
-
-	// Average luma in the correct direction.
-	float luma_local_average = 0.0;
-
-	if(is_1_steepest){
-		// Switch the direction
-		step_length = - step_length;
-		luma_local_average = 0.5*(luma1 + luma_center);
-	} else {
-		luma_local_average = 0.5*(luma2 + luma_center);
-	}
-
-	// Shift UV in the correct direction by half a pixel.
-	float2 current_uv = uv;
-	if(is_horizontal){
-		current_uv.y += step_length * 0.5;
-
-	} else {
-		current_uv.x += step_length * 0.5;
-	}
-
-	// Compute offset (for each iteration step) in the right direction.
-	float2 offset = is_horizontal ? float2(inv_width,0.0) : float2(0.0,inv_height);
-	// Compute UVs to explore on each side of the edge, orthogonally. The QUALITY allows us to step faster.
-	float2 uv1 = current_uv - offset;
-	float2 uv2 = current_uv + offset;
-
-
-	float luma_end1,luma_end2;
-	bool reached1 = false;
-	bool reached2 = false;
-	bool reached_both = false;
-
-	// Keep searching
-	if(!reached_both){
-
-		for(int i = 0; i < 20; i++){
-			// If needed, read luma in 1st direction, compute delta.
-			if(!reached1){
-				luma_end1 = rgb2luma(image.Sample(def_sampler, uv1).rgb);
-				luma_end1 = luma_end1 - luma_local_average;
-			}
-			// If needed, read luma in opposite direction, compute delta.
-			if(!reached2){
-				luma_end2 = rgb2luma(image.Sample(def_sampler, uv2).rgb);
-				luma_end2 = luma_end2 - luma_local_average;
-			}
-			// If the luma deltas at the current extremities is larger than the local gradient, we have reached the side of the edge.
-			reached1 = abs(luma_end1) >= gradient_scaled;
-			reached2 = abs(luma_end2) >= gradient_scaled;
-			reached_both = reached1 && reached2;
-
-			// If the side is not reached, we continue to explore in this direction, with a variable quality.
-			if(!reached1){
-				uv1 -= offset * QUALITY(i);
-			}
-			if(!reached2){
-				uv2 += offset * QUALITY(i);
-			}
-
-			// If both sides have been reached, stop the exploration.
-			if(reached_both){ break;}
-		}
-
-	}
-
-	// Compute the distances to each extremity of the edge.
-	float distance1 = is_horizontal ? (uv.x - uv1.x) : (uv.y - uv1.y);
-	float distance2 = is_horizontal ? (uv2.x - uv.x) : (uv2.y - uv.y);
-
-	// In which direction is the extremity of the edge closer ?
-	bool is_direction1 = distance1 < distance2;
-
-	float distance_final = min(distance1, distance2);
-
-	// Length of the edge.
-	float edge_thickness = (distance1 + distance2);
-
-	// UV offset: read in the direction of the closest side of the edge.
-	float edge_blend = - distance_final / edge_thickness + 0.5;
-
-	// Is the luma at center smaller than the local average ?
-	bool is_luma_center_smaller = luma_center < luma_local_average;
-
-	// If the luma at center is smaller than at its neighbour, the delta luma at each end should be positive (same variation).
-	// (in the direction of the closer side of the edge.)
-	bool correct_variation = ((is_direction1 ? luma_end1 : luma_end2) < 0.0) != is_luma_center_smaller;
-
-	// If the luma variation is incorrect, do not offset.
-	float final_offset = correct_variation ? edge_blend : 0.0;
-
-	// Sub-pixel shifting
-	// Full weighted average of the luma over the 3x3 neighborhood.
-	float luma_average = (1.0/12.0) * (2.0 * (luma_down_up + luma_left_right) + luma_left_corners + luma_right_corners);
-	// Ratio of the delta between the global average and the center luma, over the luma range in the 3x3 neighborhood.
-	float sub_pixel_offset1 = clamp(abs(luma_average - luma_center)/luma_contrast,0.0,1.0);
-	float sub_pixel_offset2 = (-2.0 * sub_pixel_offset1 + 3.0) * sub_pixel_offset1 * sub_pixel_offset1;
-	// Compute a sub-pixel offset based on this delta.
-	float sub_pixel_offset_final = sub_pixel_offset2 * sub_pixel_offset2 * SUBPIXEL_QUALITY;
-	sub_pixel_offset_final=sub_pixel_offset1;
-
-	// Pick the biggest of the two offsets.
-	final_offset = max(final_offset,sub_pixel_offset_final);
-
-	// return float4(final_offset,0,0,1);
-		// Compute the final UV coordinates.
-	float2 final_uv = uv;
-	if(is_horizontal){
-		final_uv.y += final_offset * step_length;
-	} else {
-		final_uv.x += final_offset * step_length;
-	}
-
-	// Read the color at the new UV coordinates, and use it.
-	return image.SampleLevel(def_sampler,final_uv,0);
-	// return average(final_uv);
-
-}
-
-
 float4 average(float2 uv) {
 	float4 samp1 = image.Sample(def_sampler, uv);
 	float4 samp2 = image.Sample(def_sampler, uv, int2(0,-1));
@@ -283,31 +46,17 @@ float4 average(float2 uv) {
 	float4 samp8 = image.Sample(def_sampler, uv, int2(-1,+1));
 	float4 samp9 = image.Sample(def_sampler, uv, int2(-1,-1));
 	return (samp1 + samp2 + samp3 + samp4 + samp5 + samp6 + samp7 + samp8 + samp9) / 9.0;
-	// return (samp7+samp4+samp3+samp2) / 4.0;
 }
 
 float4 PSDrawBare(VertInOut vert_in) : TARGET
 {
 	float4 orig = image.SampleLevel(def_sampler, vert_in.uv, 0);
 	if(antialiasing_method == NO_ANTI_ALIASING)
-		return image.SampleLevel(def_sampler, vert_in.uv, 0);
+		return orig;
 	else if(antialiasing_method == SSAA)
-		// return float4(average(vert_in.uv).rgb-orig.rgb,orig.a);
 		return average(vert_in.uv);
-	else if(antialiasing_method == FXAA)
-	{
-		return fxaa(vert_in.uv);
-	}
 	else
-		return image.Sample(def_sampler, vert_in.uv);
-	// return average(fxaa(vert_in.uv));
-}
-
-float4 PSDrawMatrix(VertInOut vert_in) : TARGET
-{
-	float4 yuv = image.Sample(def_sampler, vert_in.uv);
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+		return orig;
 }
 
 technique Draw
@@ -316,14 +65,5 @@ technique Draw
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawBare(vert_in);
-	}
-}
-
-technique DrawMatrix
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawMatrix(vert_in);
 	}
 }

--- a/gs/gs-effect.h
+++ b/gs/gs-effect.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <map>
 #include "plugin/exceptions.h"
 extern "C" {
 	#pragma warning( push )
@@ -95,8 +96,18 @@ namespace GS {
 		std::vector<EffectParameter> GetParameters();
 		EffectParameter GetParameterByName(std::string name);
 
+		static void destroy_pool();
 
 		protected:
 		gs_effect_t* m_effect;
+		std::string m_name;
+
+		// caching
+		static const size_t MAX_POOL_SIZE;
+		static std::map<std::string, std::pair<size_t, gs_effect_t*> > pool;
+		static void add_to_cache(std::string, gs_effect_t*);
+		static void load_from_cache(std::string, gs_effect_t**);
+		static void unload_effect(std::string, gs_effect_t *);
+
 	};
 }

--- a/gs/gs-texture.h
+++ b/gs/gs-texture.h
@@ -20,6 +20,7 @@
 #pragma once
 #include <inttypes.h>
 #include <string>
+#include <map>
 #include "plugin/exceptions.h"
 #include <sys/stat.h>
 #include <fstream>
@@ -83,14 +84,14 @@ namespace GS {
 		 * \brief Create a new cube texture from data
 		 *
 		 *
-		 *
+		 * \param name
 		 * \param size
 		 * \param format
 		 * \param mip_levels
 		 * \param mip_data
 		 * \param flags
 		 */
-		Texture(uint32_t size, gs_color_format format, 
+		Texture(std::string name,uint32_t size, gs_color_format format, 
 			uint32_t mip_levels, const uint8_t **mip_data,
 			uint32_t flags);
 
@@ -146,10 +147,23 @@ namespace GS {
 		 */
 		gs_texture_t* GetObject();
 
+
+		static void destroy_pool();
+
+
 		protected:
 		gs_texture_t* m_texture;
 		bool m_destroy;
+		std::string m_name;
 
 		void DestroyTexture();
+
+		// caching, for now only the cubemaps 
+		static const size_t MAX_POOL_SIZE;
+		static std::map<std::string, std::pair<size_t, gs_texture_t*> > pool;
+		static void add_to_cache(std::string, gs_texture_t*);
+		static void load_from_cache(std::string, gs_texture_t**);
+		static void unload_texture(std::string, gs_texture_t *);
+
 	};
 }

--- a/mask/mask-resource-effect.cpp
+++ b/mask/mask-resource-effect.cpp
@@ -26,6 +26,55 @@ extern "C" {
 #include <libobs/graphics/graphics.h>
 }
 
+const std::map<std::string, std::string> Mask::Resource::Effect::g_textureTypes = {
+			{"ambientTex", "AMBIENT_TEX"},
+			{"diffuseTex", "DIFFUSE_TEX"},
+			{"specularTex", "SPECULAR_TEX"},
+			{"emissiveTex", "EMISSIVE_TEX"},
+			{"normalTex", "NORMAL_TEX"},
+			{"reflectTex", "REFLECT_TEX"},
+			{"iblSpecTex", "IBL_SPEC_TEX"},
+			{"iblDiffTex", "IBL_DIFF_TEX"},
+			{"iblBRDFTex", "IBL_BRDF_TEX"},
+			{"roughnessTex", "ROUGHNESS_TEX"},
+			{"metalnessTex", "METALNESS_TEX"},
+			{"metallicRoughnessTex", "METALLICROUGHNESS_TEX"},
+			{"vidLightingTex", "USE_VIDEO_LIGHTING"}
+};
+
+
+std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, std::string filename, std::vector<std::string> active_textures)
+{
+	char *file_string;
+	file_string = os_quick_read_utf8_file(filename.c_str());
+	if (!file_string) {
+		blog(LOG_ERROR, "Could not load effect file '%s'", filename.c_str());
+		return nullptr;
+	}
+
+	/*
+		These #defines can be applied cleaner.
+		However, it will require modifying libobs
+		to support getting defines parameters for
+		compiling textures as well. Currently, it just
+		sets the parameter for DX to null.
+		TODO Mod libobs, or just port to direct OpenGL
+	*/
+	std::string dynamic_shader_string;
+	std::string unique_name = name;
+
+	for (const std::string &tex_type : active_textures) {
+		if (g_textureTypes.find(tex_type) != g_textureTypes.end()) {
+			dynamic_shader_string += "#define " + g_textureTypes.at(tex_type) + "\n";
+		}
+		unique_name += "_" + tex_type;
+	}
+	dynamic_shader_string += file_string;
+	bfree(file_string);
+
+	return std::make_shared<GS::Effect>(dynamic_shader_string, unique_name);
+}
+
 Mask::Resource::Effect::Effect(Mask::MaskData* parent, std::string name, obs_data_t* data)
 	: IBase(parent, name) {
 	const char* const S_DATA = "data";
@@ -68,47 +117,7 @@ void Mask::Resource::Effect::Render(Mask::Part* part) {
 	UNUSED_PARAMETER(part);
 	if (m_Effect == nullptr) {
 
-		static const std::map<std::string, std::string> g_textureTypes = {
-			{"ambientTex", "AMBIENT_TEX"},
-			{"diffuseTex", "DIFFUSE_TEX"},
-			{"specularTex", "SPECULAR_TEX"},
-			{"emissiveTex", "EMISSIVE_TEX"},
-			{"normalTex", "NORMAL_TEX"},
-			{"reflectTex", "REFLECT_TEX"},
-			{"iblSpecTex", "IBL_SPEC_TEX"},
-			{"iblDiffTex", "IBL_DIFF_TEX"},
-			{"iblBRDFTex", "IBL_BRDF_TEX"},
-			{"roughnessTex", "ROUGHNESS_TEX"},
-			{"metalnessTex", "METALNESS_TEX"},
-			{"metallicRoughnessTex", "METALLICROUGHNESS_TEX"},
-			{"vidLightingTex", "USE_VIDEO_LIGHTING"}
-		};
-
-		char *file_string;
-		file_string = os_quick_read_utf8_file(m_filename.c_str());
-		if (!file_string) {
-			blog(LOG_ERROR, "Could not load effect file '%s'", m_filename.c_str());
-			return;
-		}
-
-		/*
-			These #defines can be applied cleaner.
-			However, it will require modifying libobs
-			to support getting defines parameters for
-			compiling textures as well. Currently, it just
-			sets the parameter for DX to null.
-			TODO Mod libobs, or just port to direct OpenGL
-		*/
-		std::string dynamic_shader_string;
-		for (const std::string &tex_type : m_active_textures) {
-			if (g_textureTypes.find(tex_type) != g_textureTypes.end()) {
-				dynamic_shader_string += "#define " + g_textureTypes.at(tex_type) + "\n";
-			}
-		}
-		dynamic_shader_string += file_string;
-		bfree(file_string);
-
-		m_Effect = std::make_shared<GS::Effect>(dynamic_shader_string, m_filename);
+		m_Effect = Effect::compile(m_name, m_filename, m_active_textures);
 
 		if (m_filenameIsTemp) {
 			Utils::DeleteTempFile(m_filename);

--- a/mask/mask-resource-effect.h
+++ b/mask/mask-resource-effect.h
@@ -41,6 +41,9 @@ namespace Mask {
 			virtual void Update(Mask::Part* part, float time) override;
 			virtual void Render(Mask::Part* part) override;
 
+			static const std::map<std::string, std::string> g_textureTypes;
+			static std::shared_ptr<GS::Effect> compile(std::string name, std::string filename, std::vector<std::string> active_textures);
+
 			void SetActiveTextures(const std::vector<std::string> &textures) { m_active_textures = textures; }
 			std::vector<std::string> GetActiveTextures() { return m_active_textures; }
 

--- a/mask/mask-resource-effect.h
+++ b/mask/mask-resource-effect.h
@@ -42,6 +42,7 @@ namespace Mask {
 			virtual void Render(Mask::Part* part) override;
 
 			void SetActiveTextures(const std::vector<std::string> &textures) { m_active_textures = textures; }
+			std::vector<std::string> GetActiveTextures() { return m_active_textures; }
 
 		protected:
 			std::shared_ptr<GS::Effect> m_Effect;

--- a/mask/mask-resource-image.cpp
+++ b/mask/mask-resource-image.cpp
@@ -219,7 +219,7 @@ Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, obs_data_
 					sides_mips[side * m_mipLevels + i] = m_decoded_mips[side * m_mipLevels + i].data();
 				}
 			}
-			m_Texture = std::make_shared<GS::Texture>(m_width, m_fmt, m_mipLevels, sides_mips, 0);
+			m_Texture = std::make_shared<GS::Texture>(m_name, m_width, m_fmt, m_mipLevels, sides_mips, 0);
 			m_decoded_mips.clear();
 		}
 		else {
@@ -270,7 +270,7 @@ void Mask::Resource::Image::Render(Mask::Part* part) {
 						sides_mips[side * m_mipLevels + i] = m_decoded_mips[side * m_mipLevels + i].data();
 					}
 				}
-				m_Texture = std::make_shared<GS::Texture>(m_width, m_fmt, m_mipLevels, sides_mips, 0);
+				m_Texture = std::make_shared<GS::Texture>(m_name, m_width, m_fmt, m_mipLevels, sides_mips, 0);
 				m_decoded_mips.clear();
 			}
 			else {

--- a/mask/mask-resource-image.cpp
+++ b/mask/mask-resource-image.cpp
@@ -203,6 +203,34 @@ Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, obs_data_
 		throw std::logic_error("Image has no data.");
 	}
 
+
+	// temp file?
+	if (m_tempFile.length() > 0) {
+		m_Texture = std::make_shared<GS::Texture>(m_tempFile);
+		Utils::DeleteTempFile(m_tempFile);
+		m_tempFile.clear();
+	}
+	else {
+		if (m_is_cubemap) {
+			const uint8_t* sides_mips[MAX_MIP_LEVELS * 6];
+			for (size_t side = 0; side < 6; side++)
+			{
+				for (int i = 0; i < m_mipLevels; i++) {
+					sides_mips[side * m_mipLevels + i] = m_decoded_mips[side * m_mipLevels + i].data();
+				}
+			}
+			m_Texture = std::make_shared<GS::Texture>(m_width, m_fmt, m_mipLevels, sides_mips, 0);
+			m_decoded_mips.clear();
+		}
+		else {
+			const uint8_t* mips[MAX_MIP_LEVELS];
+			for (int i = 0; i < m_mipLevels; i++) {
+				mips[i] = m_decoded_mips[i].data();
+			}
+			m_Texture = std::make_shared<GS::Texture>(m_width, m_height, m_fmt, m_mipLevels, mips, 0);
+			m_decoded_mips.clear();
+		}
+	}
 }
 
 Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, std::string filename) 

--- a/mask/mask-resource-material.cpp
+++ b/mask/mask-resource-material.cpp
@@ -75,7 +75,7 @@ Mask::Resource::Material::Material(Mask::MaskData* parent, std::string name, obs
 		throw std::logic_error("Material has no effect.");
 	}
 	std::string effectName = obs_data_get_string(data, S_EFFECT);
-	m_effect = std::dynamic_pointer_cast<Mask::Resource::Effect>(m_parent->GetResource(effectName, true));
+	m_effect = std::dynamic_pointer_cast<Mask::Resource::Effect>(m_parent->GetResource(effectName));
 	if (m_effect == nullptr) {
 		PLOG_ERROR("Material uses unknown effect:", effectName.c_str());
 		throw std::logic_error("Material uses non-existing effect.");
@@ -327,7 +327,13 @@ Mask::Resource::Material::Material(Mask::MaskData* parent, std::string name, obs
 	else
 		m_use_video_lighting = false;
 
+	// sort active textures for proper effect caching
+	std::sort(active_textures.begin(), active_textures.end());
+
 	m_effect->SetActiveTextures(active_textures);
+
+	// early optimization is root of all evil
+	m_effect->Render(nullptr);
 }
 
 Mask::Resource::Material::~Material() {

--- a/mask/mask-resource-mesh.cpp
+++ b/mask/mask-resource-mesh.cpp
@@ -106,6 +106,17 @@ Mask::Resource::Mesh::Mesh(Mask::MaskData* parent, std::string name, obs_data_t*
 		obs_data_get_vec3(data, S_CENTER, &center);
 	}
 	vec4_set(&m_center, center.x, center.y, center.z, 1.0f);
+
+	// create GS resources
+	if (m_tempFile.length() > 0) {
+		LoadObj(m_tempFile);
+		Utils::DeleteTempFile(m_tempFile);
+		m_tempFile.clear();
+	}
+	else {
+		m_VertexBuffer = std::make_shared<GS::VertexBuffer>(m_rawVertices);
+		m_IndexBuffer = std::make_shared<GS::IndexBuffer>(m_rawIndices, m_numIndices);
+	}
 } 
 
 Mask::Resource::Mesh::Mesh(Mask::MaskData* parent, std::string name, std::string file)
@@ -127,19 +138,6 @@ void Mask::Resource::Mesh::Update(Mask::Part* part, float time) {
 
 void Mask::Resource::Mesh::Render(Mask::Part* part) {
 	UNUSED_PARAMETER(part);
-
-	if (m_VertexBuffer == nullptr) {
-		// create GS resources
-		if (m_tempFile.length() > 0) {
-			LoadObj(m_tempFile);
-			Utils::DeleteTempFile(m_tempFile);
-			m_tempFile.clear();
-		}
-		else {
-			m_VertexBuffer = std::make_shared<GS::VertexBuffer>(m_rawVertices);
-			m_IndexBuffer = std::make_shared<GS::IndexBuffer>(m_rawIndices, m_numIndices);
-		}
-	}
 
 	gs_load_vertexbuffer(m_VertexBuffer->get());
 	gs_load_indexbuffer(m_IndexBuffer->get());

--- a/mask/mask.cpp
+++ b/mask/mask.cpp
@@ -288,6 +288,14 @@ std::shared_ptr<Mask::Resource::IBase> Mask::MaskData::GetResource(const std::st
 	// Default Resources
 	std::shared_ptr<Mask::Resource::IBase> p = Resource::IBase::LoadDefault(this, name);
 	if (p) {
+		// if resource is an effect, change to name to include active #defines
+		auto effect = std::dynamic_pointer_cast<Mask::Resource::Effect>(p);
+		if (effect) {
+			// we have sorted texture vector. so for the same type of textures
+			// this will always create one unique name
+			for (const auto &t : effect->GetActiveTextures())
+				res_name += "_" + t;
+		}
 		this->AddResource(res_name, p);
 		return p;
 	}

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -169,7 +169,7 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 	}
 
 	f = obs_module_file("effects/pbr.effect");
-	// preload most frequent types of PBR
+	// preload most frequent types of PBR and Phong
 	// TODO precompile to avoid doing this during startup
 	Mask::Resource::Effect::compile("PBR", f, { "iblBRDFTex","iblDiffTex","iblSpecTex","vidLightingTex" });
 	Mask::Resource::Effect::compile("PBR", f, { "diffuseTex","iblBRDFTex","iblDiffTex","iblSpecTex","metalnessTex","normalTex","vidLightingTex" });
@@ -179,6 +179,21 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 	if (f) {
 		bfree(f);
 	}
+
+	f = obs_module_file("effects/phong.effect");
+	Mask::Resource::Effect::compile("effectPhong", f, { "diffuseTex" });
+	if (f) {
+		bfree(f);
+	}
+
+	// preload cubemaps
+	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_museum_specular");
+	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_mossy_forest_specular");
+	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_cayley_interior_specular");
+
+	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_museum_diffuse");
+	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_mossy_forest_diffuse");
+	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_cayley_interior_diffuse");
 
 
 	vidLightTex = NULL;
@@ -268,8 +283,9 @@ Plugin::FaceMaskFilter::Instance::~Instance() {
 	maskData = nullptr;
 	obs_leave_graphics();
 
-	// also destroy effect pool
+	// also destroy effect and texture pool
 	GS::Effect::destroy_pool();
+	GS::Texture::destroy_pool();
 
 	delete smllFaceDetector;
 	delete smllRenderer;

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -129,7 +129,7 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 	alertDoOutro(false), alertDuration(10.0f),
 	alertElapsedTime(BIG_FLOAT), alertTriggered(false), alertShown(false), alertsLoaded(false),
 	demoCurrentMask(0),
-	demoModeInDelay(false), demoModeGenPreviews(false),	demoModeSavingFrames(false), 
+	demoModeInDelay(false), demoModeGenPreviews(false),	demoModeSavingFrames(false), loading_mask(false),
 	drawMask(true),	drawAlert(false), drawFaces(false), drawMorphTris(false), drawFDRect(false), drawMotionRect(false),
 	filterPreviewMode(false), autoBGRemoval(false), cartoonMode(false), testingStage(nullptr), testMode(false), antialiasing_effect(nullptr), color_grading_filter_effect(nullptr),
 	lastResultIndex(-1), sameFrameResults(false), logMode(false), lastLogMode(false), timestampInited(false), lastTimestampInited(false) {
@@ -1508,101 +1508,108 @@ int32_t Plugin::FaceMaskFilter::Instance::LocalThreadMain() {
 	TimeStamp lastTimestamp;
 	while (true) {
 
-		auto frameStart = std::chrono::system_clock::now();
-
-		// get the frame index
-		bool shutdown;
-		{
-			std::unique_lock<std::mutex> lock(detection.mutex);
-			shutdown = detection.shutdown;
-		}
-		if (shutdown) break;
-		if (!detection.frame.active) {
-			std::this_thread::sleep_for(std::chrono::milliseconds(16));
+		if (loading_mask) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(20));
 			continue;
 		}
-
-		smll::DetectionResults detect_results;
-
-
-		bool skipped = false;
 		{
-			std::unique_lock<std::mutex> lock(detection.frame.mutex);
+			std::unique_lock<std::mutex> lockMaskDetect(loadMaskDetectionMutex);
+			auto frameStart = std::chrono::system_clock::now();
 
-			// check to see if we are detecting the same frame as last time
-			if (lastTimestamp == detection.frame.timestamp) {
-				// same frame, skip
-				skipped = true;
+			// get the frame index
+			bool shutdown;
+			{
+				std::unique_lock<std::mutex> lock(detection.mutex);
+				shutdown = detection.shutdown;
 			}
-			else {
-				// new frame - do the face detection
-				smllFaceDetector->DetectFaces(detection.frame.grayImage, detection.frame.resizeWidth, detection.frame.resizeHeight, detect_results);
-
-				smllFaceDetector->DetectLandmarks(detect_results);
-				smllFaceDetector->DoPoseEstimation(detect_results);
-
-				lastTimestamp = detection.frame.timestamp;
+			if (shutdown) break;
+			if (!detection.frame.active) {
+				std::this_thread::sleep_for(std::chrono::milliseconds(16));
+				continue;
 			}
-		}
 
-		if (skipped) {
-			// sleep for 1ms and continue
-			std::this_thread::sleep_for(std::chrono::milliseconds(1));
-			continue;
-		}
+			smll::DetectionResults detect_results;
 
-		// get the index into the faces buffer
-		int face_idx;
-		{
-			std::unique_lock<std::mutex> lock(detection.mutex);
-			face_idx = detection.facesIndex;
-		}
-		if (face_idx < 0)
-			face_idx = 0;
 
-		{
-			std::unique_lock<std::mutex> facelock(detection.faces[face_idx].mutex);
+			bool skipped = false;
+			{
+				std::unique_lock<std::mutex> lock(detection.frame.mutex);
 
-			// pass on timestamp to results
-			detection.faces[face_idx].timestamp = lastTimestamp;
-			std::unique_lock<std::mutex> framelock(detection.frame.mutex);
+				// check to see if we are detecting the same frame as last time
+				if (lastTimestamp == detection.frame.timestamp) {
+					// same frame, skip
+					skipped = true;
+				}
+				else {
+					// new frame - do the face detection
+					smllFaceDetector->DetectFaces(detection.frame.grayImage, detection.frame.resizeWidth, detection.frame.resizeHeight, detect_results);
 
-			// Make the triangulation
-			detection.faces[face_idx].triangulationResults.buildLines = drawMorphTris;
-			smllFaceDetector->MakeTriangulation(detection.frame.morphData,
-				detect_results, detection.faces[face_idx].triangulationResults);
+					smllFaceDetector->DetectLandmarks(detect_results);
+					smllFaceDetector->DoPoseEstimation(detect_results);
 
-			detection.frame.active = false;
-	
-
-			// Copy our detection results
-			for (int i = 0; i < detect_results.length; i++) {
-				detection.faces[face_idx].detectionResults[i] = detect_results[i];
+					lastTimestamp = detection.frame.timestamp;
+				}
 			}
-			detection.faces[face_idx].detectionResults.length = detect_results.length;
-			detection.faces[face_idx].detectionResults.processedResults = detect_results.processedResults;
-			detection.faces[face_idx].detectionResults.motionRect = detect_results.motionRect;
 
+			if (skipped) {
+				// sleep for 1ms and continue
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+				continue;
+			}
+
+			// get the index into the faces buffer
+			int face_idx;
+			{
+				std::unique_lock<std::mutex> lock(detection.mutex);
+				face_idx = detection.facesIndex;
+			}
+			if (face_idx < 0)
+				face_idx = 0;
+
+			{
+				std::unique_lock<std::mutex> facelock(detection.faces[face_idx].mutex);
+
+				// pass on timestamp to results
+				detection.faces[face_idx].timestamp = lastTimestamp;
+				std::unique_lock<std::mutex> framelock(detection.frame.mutex);
+
+				// Make the triangulation
+				detection.faces[face_idx].triangulationResults.buildLines = drawMorphTris;
+				smllFaceDetector->MakeTriangulation(detection.frame.morphData,
+					detect_results, detection.faces[face_idx].triangulationResults);
+
+				detection.frame.active = false;
+
+
+				// Copy our detection results
+				for (int i = 0; i < detect_results.length; i++) {
+					detection.faces[face_idx].detectionResults[i] = detect_results[i];
+				}
+				detection.faces[face_idx].detectionResults.length = detect_results.length;
+				detection.faces[face_idx].detectionResults.processedResults = detect_results.processedResults;
+				detection.faces[face_idx].detectionResults.motionRect = detect_results.motionRect;
+
+			}
+
+			{
+				std::unique_lock<std::mutex> lock(detection.mutex);
+
+				// increment face buffer index
+				detection.facesIndex = (face_idx + 1) % ThreadData::BUFFER_SIZE;
+			}
+
+			// don't go too fast and eat up all the cpu
+			auto frameEnd = std::chrono::system_clock::now();
+			auto elapsedMs =
+				std::chrono::duration_cast<std::chrono::microseconds>
+				(frameEnd - frameStart);
+			long long speedLimit = smll::Config::singleton().get_int(
+				smll::CONFIG_INT_SPEED_LIMIT) * 1000;
+			long long sleepTime = max(speedLimit - elapsedMs.count(),
+				(long long)0);
+			if (sleepTime > 0)
+				std::this_thread::sleep_for(std::chrono::microseconds(sleepTime));
 		}
-
-		{
-			std::unique_lock<std::mutex> lock(detection.mutex);
-
-			// increment face buffer index
-			detection.facesIndex = (face_idx + 1) % ThreadData::BUFFER_SIZE;
-		}
-
-		// don't go too fast and eat up all the cpu
-		auto frameEnd = std::chrono::system_clock::now();
-		auto elapsedMs =
-			std::chrono::duration_cast<std::chrono::microseconds>
-			(frameEnd - frameStart);
-		long long speedLimit = smll::Config::singleton().get_int(
-			smll::CONFIG_INT_SPEED_LIMIT) * 1000;
-		long long sleepTime = max(speedLimit - elapsedMs.count(),
-			(long long)0);
-		if (sleepTime > 0)
-			std::this_thread::sleep_for(std::chrono::microseconds(sleepTime));
 	}
 
 	if (hTask != NULL) {
@@ -1641,7 +1648,15 @@ int32_t Plugin::FaceMaskFilter::Instance::LocalMaskDataThreadMain() {
 					std::string maskFn = currentMaskFolder + "\\" + currentMaskFilename;
 					// load mask
 					SetThreadPriority(GetCurrentThread(), THREAD_MODE_BACKGROUND_BEGIN);
-					maskData = std::unique_ptr<Mask::MaskData>(LoadMask(maskFn));
+					{
+						loading_mask = true;
+						{
+							std::unique_lock<std::mutex> lock(loadMaskDetectionMutex);
+							maskData = std::unique_ptr<Mask::MaskData>(LoadMask(maskFn));
+						}
+						loading_mask = false;
+
+					}
 					SetThreadPriority(GetCurrentThread(), THREAD_MODE_BACKGROUND_END);
 				}
 

--- a/plugin/face-mask-filter.h
+++ b/plugin/face-mask-filter.h
@@ -190,8 +190,9 @@ namespace Plugin {
 			std::unique_ptr<Mask::MaskData>	introData;
 			std::unique_ptr<Mask::MaskData>	outroData;
 
+			bool				loading_mask;
 			std::mutex          passFrameToDetection;
-
+			std::mutex          loadMaskDetectionMutex;
 			// alert location
 			enum AlertLocation {
 				LEFT_BOTTOM,


### PR DESCRIPTION
Three levels of caching for loading effects/cubemap textures:

1. Re-use effects/cubemaps for different materials in each mask
2. Re-use effects/cubemaps for subsequent masks
3. Pre-load most frequent type of effects/cubemaps

This is done using a pool of effects with a fixed maximum size to avoid using up memory.