### PR TITLE
Fix for phong shader caching + Omit smllRenderer on release

### DIFF
--- a/data/effects/pbr.effect
+++ b/data/effects/pbr.effect
@@ -29,14 +29,10 @@ uniform int ambientMap = 0;
 uniform texture2d ambientTex;
 uniform int diffuseMap = 0;
 uniform texture2d diffuseTex;
-uniform int specularMap = 0;
-uniform texture2d specularTex;
 uniform int emissiveMap = 0;
 uniform texture2d emissiveTex;
 uniform int normalMap = 0;
 uniform texture2d normalTex;
-uniform int reflectMap = 0;
-uniform texture2d reflectTex;
 
 uniform int iblSpecMap = 0;
 uniform texture_cube iblSpecTex;
@@ -532,7 +528,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 	// normal
 	float3 normal = normalize(v_in.norm);
 
-#ifdef NORMAL_TEX	
+//#ifdef NORMAL_TEX	
 	if (normalMap != 0) {
 		float3 tangent = normalize(v_in.tangent);
 		float3 bitangent = normalize(v_in.bitangent);
@@ -541,7 +537,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 		normal = normalTex.Sample(tex_sampler, v_in.uv).xyz * 2.0 - 1.0;
 		normal = normalize(mul(normal, TBN));
 	}
-#endif
+//#endif
 
 	// material colors
 	float4 ambColor = ambientColor;
@@ -554,37 +550,32 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 	float _metalness = metalness;
 
 	// texture maps
-#ifdef AMBIENT_TEX
+//#ifdef AMBIENT_TEX
 	if (ambientMap != 0)
 		ambColor = ambientTex.Sample(tex_sampler, v_in.uv);
-#endif
+//#endif
 
-#ifdef DIFFUSE_TEX
+//#ifdef DIFFUSE_TEX
 	if (diffuseMap != 0)
 		albedoColor = diffuseTex.Sample(tex_sampler, v_in.uv);
-#endif
+//#endif
 
-#ifdef DISABLED_SPECULAR_TEX
-	if (specularMap != 0)
-		spcColor = specularTex.Sample(tex_sampler, v_in.uv);
-#endif
-
-#ifdef EMISSIVE_TEX
+//#ifdef EMISSIVE_TEX
 	if (emissiveMap != 0)
 		emmColor = emissiveTex.Sample(tex_sampler, v_in.uv);
-#endif
+//#endif
 
-#ifdef ROUGHNESS_TEX
+//#ifdef ROUGHNESS_TEX
 	if (roughnessMap != 0)
 		_roughness = max(0.04, roughnessTex.Sample(tex_sampler, v_in.uv).r);
-#endif
+//#endif
 
-#ifdef METALNESS_TEX
+//#ifdef METALNESS_TEX
 	if (metalnessMap != 0)
 		_metalness = metalnessTex.Sample(tex_sampler, v_in.uv).r;
-#endif
+//#endif
 
-#ifdef METALLICROUGHNESS_TEX
+//#ifdef METALLICROUGHNESS_TEX
 	if (metallicRoughnessMap != 0) {
 		// R: Occlusion
 		// G: Roughness
@@ -594,7 +585,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 		_roughness = max(0.04, metallic_roughness.g);
 		_metalness = metallic_roughness.b;
 	}
-#endif
+//#endif
 
 	// convert srgb to linear
 	albedoColor = srgb_to_linear(albedoColor);
@@ -603,7 +594,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 	// Start with full transparent color
 	float4 base_color = {0,0,0,0};	
 
-#ifdef IBL_SPEC_TEX
+//#ifdef IBL_SPEC_TEX
 	if (iblSpecMap != 0 && iblBRDFMap != 0 && iblDiffMap != 0) {
 		float3 r = -normalize(reflect(-vpos, normal));
 
@@ -617,13 +608,13 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 		float4 ibl_spec_light = iblSpecTex.SampleLevel(tex_sampler, rotate_env_map(float3(-r.x, -r.y, r.z), ibl_rotate_offset), lod);
 		float4 ibl_diff_light = iblDiffTex.Sample(tex_sampler, rotate_env_map(float3(-normal.x, -normal.y, normal.z), ibl_rotate_offset));
 
-#ifdef IBL_BRDF_TEX
+//#ifdef IBL_BRDF_TEX
 		float3 brdf = iblBRDFTex.Sample(tex_sampler,float2(NdV, 1.0 - _roughness)).rgb;
 		float3 reflectivity = specular_color*brdf.x+brdf.y;
-#else
-		// not accurate at all, just a fallback to avoid the shader fail fully
-		float3 reflectivity = specular_color*saturate((1.0-_roughness)*NdV+1.0*(1.0-_roughness));
-#endif
+//#else
+//		// not accurate at all, just a fallback to avoid the shader fail fully
+//		float3 reflectivity = specular_color*saturate((1.0-_roughness)*NdV+1.0*(1.0-_roughness));
+//#endif
 
 		float3 kr = reflectivity;
 		float3 kd = (1.0 - kr) * albedoColor.a * albedoColor.rgb * (1.0 - _metalness);
@@ -646,7 +637,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 
 		base_color += float4(ibl_intensity*(ibl_diff_light.rgb*kd + ibl_spec_light.rgb*kr), opacity);
 	}
-	#endif
+	//#endif
 	
 	// NO LIGHTS
 	if (numLights == 0) {
@@ -761,7 +752,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 
 	float3 brightness_factor = {.30, .59, .11};
 
-#ifdef USE_VIDEO_LIGHTING
+//#ifdef USE_VIDEO_LIGHTING
 	// alpha from vidLightingTex contains brightness
 	// rgb is dominant bright color
 	float4 video_bright_color = vidLightingTex.Sample(tex_sampler, float2((normal.x+1)/2, (normal.y+1)/2));
@@ -773,7 +764,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 		final_color_balance += 5 * video_bright_color.rgb;
 		final_color_balance /= 6;
 	}
-#endif
+//#endif
 
 	float3 linear_color = final_color.rgb;
 
@@ -784,10 +775,10 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 	float3 linear_color_balance = pow( final_color_balance, 2.2 );
 	float3 linear_exposure = pow( 2, final_exposure );
 
-#ifdef USE_VIDEO_LIGHTING
+//#ifdef USE_VIDEO_LIGHTING
 	if(video_brightness > 0.0)
 		linear_exposure *= brightness_to_exposure(video_brightness, 0.2);
-#endif
+//#endif
 
 	float linear_ref = 0.18;
 

--- a/gs/gs-effect.cpp
+++ b/gs/gs-effect.cpp
@@ -85,6 +85,7 @@ void GS::Effect::destroy_pool() {
 		gs_effect_destroy(ent.second.second);
 		obs_leave_graphics();
 	}
+	pool.clear();
 }
 
 GS::Effect::Effect(std::string file) {

--- a/gs/gs-effect.h
+++ b/gs/gs-effect.h
@@ -96,6 +96,9 @@ namespace GS {
 		std::vector<EffectParameter> GetParameters();
 		EffectParameter GetParameterByName(std::string name);
 
+		static void add_to_cache(std::string, gs_effect_t*);
+		static void load_from_cache(std::string, gs_effect_t**);
+		static void unload_effect(std::string, gs_effect_t *);
 		static void destroy_pool();
 
 		protected:
@@ -105,9 +108,6 @@ namespace GS {
 		// caching
 		static const size_t MAX_POOL_SIZE;
 		static std::map<std::string, std::pair<size_t, gs_effect_t*> > pool;
-		static void add_to_cache(std::string, gs_effect_t*);
-		static void load_from_cache(std::string, gs_effect_t**);
-		static void unload_effect(std::string, gs_effect_t *);
 
 	};
 }

--- a/gs/gs-texture.cpp
+++ b/gs/gs-texture.cpp
@@ -22,7 +22,23 @@
 
 const size_t GS::Texture::MAX_POOL_SIZE = 10;
 std::map<std::string, std::pair<size_t, gs_texture_t*> > GS::Texture::pool;
+gs_texture_t* GS::Texture::empty_texture = nullptr;
 
+
+gs_texture_t *GS::Texture::get_empty_texture() {
+	return empty_texture;
+}
+
+void GS::Texture::init_empty_texture() {
+	const uint8_t *zero_tex[1];
+	zero_tex[0] = new uint8_t[4]();
+
+	obs_enter_graphics();
+	empty_texture = gs_texture_create(1, 1, GS_RGBA, 1, (const uint8_t **)&zero_tex, 0);
+	obs_leave_graphics();
+
+	delete zero_tex[0];
+}
 
 void GS::Texture::add_to_cache(std::string name, gs_texture_t *texture) {
 
@@ -111,6 +127,13 @@ void GS::Texture::destroy_pool() {
 		}
 	}
 	pool.clear();
+	// destroy empty texture as well
+	if (empty_texture)
+	{
+		obs_enter_graphics();
+		gs_texture_destroy(empty_texture);
+		obs_leave_graphics();
+	}
 }
 
 GS::Texture::Texture(uint32_t width, uint32_t height, gs_color_format format, uint32_t mip_levels, const uint8_t **mip_data, uint32_t flags) : m_destroy(true) {

--- a/gs/gs-texture.h
+++ b/gs/gs-texture.h
@@ -148,6 +148,9 @@ namespace GS {
 		gs_texture_t* GetObject();
 
 
+		static void add_to_cache(std::string, gs_texture_t*);
+		static void load_from_cache(std::string, gs_texture_t**);
+		static void unload_texture(std::string, gs_texture_t *);
 		static void destroy_pool();
 
 
@@ -161,9 +164,6 @@ namespace GS {
 		// caching, for now only the cubemaps 
 		static const size_t MAX_POOL_SIZE;
 		static std::map<std::string, std::pair<size_t, gs_texture_t*> > pool;
-		static void add_to_cache(std::string, gs_texture_t*);
-		static void load_from_cache(std::string, gs_texture_t**);
-		static void unload_texture(std::string, gs_texture_t *);
 
 	};
 }

--- a/gs/gs-texture.h
+++ b/gs/gs-texture.h
@@ -147,7 +147,8 @@ namespace GS {
 		 */
 		gs_texture_t* GetObject();
 
-
+		static void init_empty_texture();
+		static gs_texture_t *get_empty_texture();
 		static void add_to_cache(std::string, gs_texture_t*);
 		static void load_from_cache(std::string, gs_texture_t**);
 		static void unload_texture(std::string, gs_texture_t *);
@@ -164,6 +165,7 @@ namespace GS {
 		// caching, for now only the cubemaps 
 		static const size_t MAX_POOL_SIZE;
 		static std::map<std::string, std::pair<size_t, gs_texture_t*> > pool;
+		static gs_texture_t *empty_texture;
 
 	};
 }

--- a/mask/mask-resource-effect.cpp
+++ b/mask/mask-resource-effect.cpp
@@ -38,12 +38,12 @@ const std::map<std::string, std::string> Mask::Resource::Effect::g_textureTypes 
 			{"iblBRDFTex", "IBL_BRDF_TEX"},
 			{"roughnessTex", "ROUGHNESS_TEX"},
 			{"metalnessTex", "METALNESS_TEX"},
-			{"metallicRoughnessTex", "METALLICROUGHNESS_TEX"},
-			{"vidLightingTex", "USE_VIDEO_LIGHTING"}
+			{"metallicRoughnessTex", "METALLICROUGHNESS_TEX"}/*,
+			{"vidLightingTex", "USE_VIDEO_LIGHTING"}*/
 };
 
 
-std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, std::string filename, std::vector<std::string> active_textures)
+std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, std::string filename)
 {
 	char *file_string;
 	file_string = os_quick_read_utf8_file(filename.c_str());
@@ -59,7 +59,13 @@ std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, st
 		compiling textures as well. Currently, it just
 		sets the parameter for DX to null.
 		TODO Mod libobs, or just port to direct OpenGL
-	*/
+
+	Update:
+		Using 1x1 empty textures it seems this could be avoided.
+	    This is here in case we see performance cost,
+		and have to revert to this way.
+	////////////////////////////////////////////////////////////
+
 	std::string dynamic_shader_string;
 	std::string unique_name = name;
 
@@ -73,9 +79,11 @@ std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, st
 			unique_name += "_" + tex_type;
 	}
 	dynamic_shader_string += file_string;
-	bfree(file_string);
 
-	return std::make_shared<GS::Effect>(dynamic_shader_string, unique_name);
+	*/
+	std::string code = file_string;
+	bfree(file_string);
+	return std::make_shared<GS::Effect>(code, name);
 }
 
 Mask::Resource::Effect::Effect(Mask::MaskData* parent, std::string name, obs_data_t* data)
@@ -120,7 +128,7 @@ void Mask::Resource::Effect::Render(Mask::Part* part) {
 	UNUSED_PARAMETER(part);
 	if (m_Effect == nullptr) {
 
-		m_Effect = Effect::compile(m_name, m_filename, m_active_textures);
+		m_Effect = Effect::compile(m_name, m_filename);
 
 		if (m_filenameIsTemp) {
 			Utils::DeleteTempFile(m_filename);

--- a/mask/mask-resource-effect.cpp
+++ b/mask/mask-resource-effect.cpp
@@ -63,11 +63,14 @@ std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, st
 	std::string dynamic_shader_string;
 	std::string unique_name = name;
 
+	bool requires_unique_name = (name == "PBR");
+
 	for (const std::string &tex_type : active_textures) {
 		if (g_textureTypes.find(tex_type) != g_textureTypes.end()) {
 			dynamic_shader_string += "#define " + g_textureTypes.at(tex_type) + "\n";
 		}
-		unique_name += "_" + tex_type;
+		if (requires_unique_name)
+			unique_name += "_" + tex_type;
 	}
 	dynamic_shader_string += file_string;
 	bfree(file_string);

--- a/mask/mask-resource-effect.h
+++ b/mask/mask-resource-effect.h
@@ -42,7 +42,7 @@ namespace Mask {
 			virtual void Render(Mask::Part* part) override;
 
 			static const std::map<std::string, std::string> g_textureTypes;
-			static std::shared_ptr<GS::Effect> compile(std::string name, std::string filename, std::vector<std::string> active_textures);
+			static std::shared_ptr<GS::Effect> compile(std::string name, std::string filename);
 
 			void SetActiveTextures(const std::vector<std::string> &textures) { m_active_textures = textures; }
 			std::vector<std::string> GetActiveTextures() { return m_active_textures; }

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -200,7 +200,9 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 
 	// Make the smll stuff
 	smllFaceDetector = new smll::FaceDetector();
-	smllRenderer = new smll::OBSRenderer(); 
+#if !defined(PUBLIC_RELEASE)
+	smllRenderer = new smll::OBSRenderer();
+#endif
 
 	// set our mm thread task
 	if (!taskHandle) {
@@ -288,7 +290,9 @@ Plugin::FaceMaskFilter::Instance::~Instance() {
 	GS::Texture::destroy_pool();
 
 	delete smllFaceDetector;
+#if !defined(PUBLIC_RELEASE)
 	delete smllRenderer;
+#endif
 
 	if (taskHandle != NULL) {
 		AvRevertMmThreadCharacteristics(taskHandle);
@@ -971,8 +975,10 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 		return;
 	}
 
+#if !defined(PUBLIC_RELEASE)
 	// smll needs a "viewport" to draw
 	smllRenderer->SetViewport(baseWidth, baseHeight);
+#endif
 
 	// set up alphas
 	bool introActive = false;
@@ -1213,10 +1219,11 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 						}
 					}
 				}
-
+#if !defined(PUBLIC_RELEASE)
 				// draw face detection data
 				if (drawFaces)
 					smllRenderer->DrawFaces(faces);
+#endif
 
 				gs_texrender_end(drawTexRender);
 			}
@@ -1299,10 +1306,11 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 			gs_draw_sprite(mask_tex, 0, baseWidth, baseHeight);
 		}
 	}
-
+#if !defined(PUBLIC_RELEASE)
 	// draw face detection data
 	if (drawFaces)
 		smllRenderer->DrawFaces(faces);
+#endif
 
 	// draw crop rectangles
 	if (drawFDRect) {
@@ -1812,6 +1820,7 @@ Plugin::FaceMaskFilter::Instance::LoadMask(std::string filename) {
 }
 
 void Plugin::FaceMaskFilter::Instance::drawCropRects(int width, int height) {
+#if !defined(PUBLIC_RELEASE)
 	dlib::rectangle r;
 	int x = (int)((float)(width / 2) *
 		smll::Config::singleton().get_double(
@@ -1836,9 +1845,11 @@ void Plugin::FaceMaskFilter::Instance::drawCropRects(int width, int height) {
 	r.set_right(x + w);
 	smllRenderer->SetDrawColor(255, 0, 255);
 	smllRenderer->DrawRect(r);
+#endif
 }
 
 void Plugin::FaceMaskFilter::Instance::drawMotionRects(int width, int height) {
+#if !defined(PUBLIC_RELEASE)
 	if (drawMotionRect) {
 		dlib::rectangle rect;
 		int t = faces.motionRect.top();
@@ -1854,6 +1865,7 @@ void Plugin::FaceMaskFilter::Instance::drawMotionRects(int width, int height) {
 			smllRenderer->DrawRect(rect, 3);
 		}
 	}
+#endif
 }
 
 void Plugin::FaceMaskFilter::Instance::updateFaces() {

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -168,20 +168,24 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 		bfree(f);
 	}
 
-	f = obs_module_file("effects/pbr.effect");
-	// preload most frequent types of PBR and Phong
+	// preload PBR and Phong
 	// TODO precompile to avoid doing this during startup
-	Mask::Resource::Effect::compile("PBR", f, { "iblBRDFTex","iblDiffTex","iblSpecTex","vidLightingTex" });
-	Mask::Resource::Effect::compile("PBR", f, { "diffuseTex","iblBRDFTex","iblDiffTex","iblSpecTex","metalnessTex","normalTex","vidLightingTex" });
-	Mask::Resource::Effect::compile("PBR", f, { "diffuseTex","iblBRDFTex","iblDiffTex","iblSpecTex","normalTex","roughnessTex","vidLightingTex" });
-	Mask::Resource::Effect::compile("PBR", f, { "diffuseTex","iblBRDFTex","iblDiffTex","iblSpecTex","metalnessTex", "normalTex","roughnessTex","vidLightingTex" });
-	Mask::Resource::Effect::compile("PBR", f, { "diffuseTex","iblBRDFTex","iblDiffTex","iblSpecTex","metallicRoughnessTex", "normalTex","vidLightingTex" });
+
+	f = obs_module_file("effects/pbr.effect");
+	Mask::Resource::Effect::compile("PBR", f);
 	if (f) {
 		bfree(f);
 	}
 
 	f = obs_module_file("effects/phong.effect");
-	Mask::Resource::Effect::compile("effectPhong", f, { "diffuseTex" });
+	Mask::Resource::Effect::compile("effectPhong", f);
+	if (f) {
+		bfree(f);
+	}
+
+	// depth head uses default effect
+	f = obs_module_file("effects/default.effect");
+	Mask::Resource::Effect::compile("effectDefault", f);
 	if (f) {
 		bfree(f);
 	}
@@ -194,6 +198,8 @@ Plugin::FaceMaskFilter::Instance::Instance(obs_data_t *data, obs_source_t *sourc
 	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_museum_diffuse");
 	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_mossy_forest_diffuse");
 	Mask::Resource::IBase::LoadDefault(nullptr, "ibl_cayley_interior_diffuse");
+
+	GS::Texture::init_empty_texture();
 
 
 	vidLightTex = NULL;

--- a/plugin/face-mask-filter.h
+++ b/plugin/face-mask-filter.h
@@ -144,8 +144,9 @@ namespace Plugin {
 			ofstream		logOutput;
 			// Face detector
 			smll::FaceDetector*		smllFaceDetector;
+#if !defined(PUBLIC_RELEASE)
 			smll::OBSRenderer*      smllRenderer;
-
+#endif
 			gs_effect_t*		antialiasing_effect = nullptr;
 			int					m_scale_rate = 1;
 			int					antialiasing_method = NO_ANTI_ALIASING;


### PR DESCRIPTION
1. Phong shader didn't need extra caching based on attached texture types. This PR fixes that so we only load the phong shader once.
2. smllRender had to load two extra effects, which would add around 300 ms to plugin load time. This is only for our testing and it's not used for release. This PR omits this object.