### PR TITLE
Fix alpha blending function to sum alphas

### DIFF
--- a/mask/mask.cpp
+++ b/mask/mask.cpp
@@ -790,8 +790,8 @@ void Mask::MaskData::Render(bool depthOnly, bool staticOnly, bool rotationDisabl
 
 	// TRANSPARENT
 	if (!depthOnly) {
-		gs_blend_function(gs_blend_type::GS_BLEND_SRCALPHA,
-			gs_blend_type::GS_BLEND_INVSRCALPHA);
+		gs_blend_function_separate(gs_blend_type::GS_BLEND_SRCALPHA,
+			gs_blend_type::GS_BLEND_INVSRCALPHA, gs_blend_type::GS_BLEND_ONE, gs_blend_type::GS_BLEND_ONE);
 
 		for (unsigned int i = 0; i < NUM_DRAW_BUCKETS; i++) {
 			SortedDrawObject* sdo = m_drawBuckets[i];


### PR DESCRIPTION
Overlaid transparent object made everything under it transparent, caused by choosing the src alpha as the final alpha. This PR will fix this issue by adding alphas. Will wait for some tests to make sure this will fix the issue completely, and will merge afterwards.