### PR TITLE
Refactor Caching + Per Instance Caching

### DIFF
--- a/gs/gs-effect.cpp
+++ b/gs/gs-effect.cpp
@@ -19,84 +19,12 @@
 
 #include "gs-effect.h"
 
-const size_t GS::Effect::MAX_POOL_SIZE = 10;
-std::map<std::string, std::pair<size_t, gs_effect_t*> > GS::Effect::pool;
-
-
-void GS::Effect::add_to_cache(std::string name, gs_effect_t *effect) {
-
-	auto it = pool.find(name);
-	if (it != pool.end() && it->second.second != nullptr) {
-		throw "Incorrect use of add_to_cache, before calling load_from_cache";
-	}
-
-	if (pool.size() < MAX_POOL_SIZE)
-	{
-		//blog(LOG_DEBUG, "Caching effect: %s", name.c_str());
-		pool[name] = std::make_pair(1, effect);
-	}
-	else
-	{
-		// remove the least re-used effect
-		auto min_it = pool.begin();
-		size_t min_ref = min_it->second.first;
-		for (auto it = pool.begin(); it != pool.end(); it++)
-		{
-			if (min_ref > it->second.first)
-			{
-				min_ref = it->second.first;
-				min_it = it;
-			}
-		}
-		pool.erase(min_it);
-		//blog(LOG_DEBUG, "Pool full. Removing least used effect: %s, #ref = %d", min_it->first.c_str(), min_it->second.first);
-
-		pool[name] = std::make_pair(1, effect);
-	}
-}
-
-void GS::Effect::load_from_cache(std::string name, gs_effect_t **effect_ptr) {
-	if (pool.find(name) != pool.end()) {
-		//blog(LOG_DEBUG, "Re-using effect: %s", name.c_str());
-		pool[name].first++;
-		*effect_ptr = pool[name].second;
-	}
-	else
-		*effect_ptr = nullptr;
-}
-
-void GS::Effect::unload_effect(std::string name, gs_effect_t *effect) {
-	// only destroy if the effect is not managed by the pool
-	if (pool.find(name) == pool.end()) {
-		//blog(LOG_DEBUG, "Destroying unmanaged effect: %s", name.c_str());
-		obs_enter_graphics();
-		if(effect)
-			gs_effect_destroy(effect);
-		obs_leave_graphics();
-		return;
-	}
-
-	//blog(LOG_DEBUG, "Delaying destroying managed effect: %s", name.c_str());
-
-}
-
-void GS::Effect::destroy_pool() {
-	obs_enter_graphics();
-	for (auto &ent : pool) {
-		//blog(LOG_DEBUG, "POOL DESTROY: destroying managed effect: %s", ent.first.c_str());
-		if (ent.second.second)
-		{
-			gs_effect_destroy(ent.second.second);
-			ent.second.second = nullptr;
-		}
-	}
-	obs_leave_graphics();
-}
-
-GS::Effect::Effect(std::string file) {
+GS::Effect::Effect(std::string file, Cache *cache):m_cache(cache) {
 	m_name = file;
 	obs_enter_graphics();
-	GS::Effect::load_from_cache(m_name, &m_effect);
+	m_effect = nullptr;
+	if (m_cache != nullptr)
+		m_cache->load(CacheableType::Effect, m_name, (void **)&m_effect);
 	if (m_effect == nullptr)
 	{
 		char* errorMessage = nullptr;
@@ -107,15 +35,18 @@ GS::Effect::Effect(std::string file) {
 			obs_leave_graphics();
 			throw std::runtime_error(error);
 		}
-		GS::Effect::add_to_cache(m_name, m_effect);
+		if (!m_cache->add(CacheableType::Effect, m_name, (void *)m_effect))
+			blog(LOG_WARNING, "Caching effect failed: %s", m_name.c_str());
 	}
 	obs_leave_graphics();
 }
 
-GS::Effect::Effect(std::string code, std::string name) {
+GS::Effect::Effect(std::string code, std::string name, Cache *cache):m_cache(cache) {
 	m_name = name;
 	obs_enter_graphics();
-	GS::Effect::load_from_cache(m_name, &m_effect);
+	m_effect = nullptr;
+	if (m_cache != nullptr)
+		m_cache->load(CacheableType::Effect, m_name, (void **)&m_effect);
 	if (m_effect == nullptr)
 	{
 		char* errorMessage = nullptr;
@@ -126,14 +57,15 @@ GS::Effect::Effect(std::string code, std::string name) {
 			obs_leave_graphics();
 			throw std::runtime_error(error);
 		}
-
-		GS::Effect::add_to_cache(m_name, m_effect);
+		if(!m_cache->add(CacheableType::Effect, m_name, (void *)m_effect))
+			blog(LOG_WARNING, "Caching effect failed: %s", m_name.c_str());
 	}
 	obs_leave_graphics();
 }
 
 GS::Effect::~Effect() {
-	GS::Effect::unload_effect(m_name, m_effect);
+	m_cache->try_destroy_resource(m_name, m_effect,
+		CacheableType::Effect);
 }
 
 gs_effect_t* GS::Effect::GetObject() {

--- a/gs/gs-effect.h
+++ b/gs/gs-effect.h
@@ -25,6 +25,8 @@
 #include <vector>
 #include <map>
 #include "plugin/exceptions.h"
+#include "mask/mask-resource.h"
+
 extern "C" {
 	#pragma warning( push )
 	#pragma warning( disable: 4201 )
@@ -87,8 +89,11 @@ namespace GS {
 
 	class Effect {
 		public:
-		Effect(std::string file);
-		Effect(std::string code, std::string name);
+		using Cache = Mask::Resource::Cache;
+		using CacheableType = Cache::CacheableType;
+
+		Effect(std::string file, Cache *cache);
+		Effect(std::string code, std::string name, Cache *cache);
 		virtual ~Effect();
 
 		gs_effect_t* GetObject();
@@ -96,18 +101,12 @@ namespace GS {
 		std::vector<EffectParameter> GetParameters();
 		EffectParameter GetParameterByName(std::string name);
 
-		static void add_to_cache(std::string, gs_effect_t*);
-		static void load_from_cache(std::string, gs_effect_t**);
-		static void unload_effect(std::string, gs_effect_t *);
-		static void destroy_pool();
-
 		protected:
 		gs_effect_t* m_effect;
 		std::string m_name;
 
-		// caching
-		static const size_t MAX_POOL_SIZE;
-		static std::map<std::string, std::pair<size_t, gs_effect_t*> > pool;
+		// cache manager from FM instance
+		Cache *m_cache;
 
 	};
 }

--- a/gs/gs-texture.h
+++ b/gs/gs-texture.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <map>
 #include "plugin/exceptions.h"
+#include "mask/mask-resource.h"
 #include <sys/stat.h>
 #include <fstream>
 extern "C" {
@@ -47,6 +48,9 @@ namespace GS {
 			BuildMipMaps,
 		};
 
+		using Cache = Mask::Resource::Cache;
+		using CacheableType = Cache::CacheableType;
+
 		public:
 		/*!
 		 * \brief Create a new texture from data
@@ -61,7 +65,8 @@ namespace GS {
 		 * \param flags
 		 */
 		Texture(uint32_t width, uint32_t height, gs_color_format format, 
-			uint32_t mip_levels, const uint8_t **mip_data, uint32_t flags);
+			uint32_t mip_levels, const uint8_t **mip_data, uint32_t flags,
+			Cache *cache);
 
 		/*!
 		 * \brief Create a new volume texture from data
@@ -78,7 +83,8 @@ namespace GS {
 		 */
 		Texture(uint32_t width, uint32_t height, uint32_t depth, 
 			gs_color_format format, uint32_t mip_levels, 
-			const uint8_t **mip_data, uint32_t flags);
+			const uint8_t **mip_data, uint32_t flags,
+			Cache *cache);
 
 		/*!
 		 * \brief Create a new cube texture from data
@@ -93,7 +99,8 @@ namespace GS {
 		 */
 		Texture(std::string name,uint32_t size, gs_color_format format, 
 			uint32_t mip_levels, const uint8_t **mip_data,
-			uint32_t flags);
+			uint32_t flags,
+			Cache *cache);
 
 		/*!
 		* \brief Load a texture from a file
@@ -105,19 +112,19 @@ namespace GS {
 		*
 		* \param file File to create the texture from.
 		*/
-		Texture(std::string file);
+		Texture(std::string file, Cache *cache);
 
 		/*!
 		* \brief Default constructor
 		*/
 		Texture() 
-			: m_texture(nullptr), m_destroy(true) {}
+			: m_texture(nullptr), m_destroy(true), m_cache(nullptr) {}
 
 		/*!
 		* \brief Wrapper constructur
 		*/
 		Texture(gs_texture* tex, bool destroy=false) 
-			: m_texture(tex), m_destroy(destroy) {}
+			: m_texture(tex), m_destroy(destroy), m_cache(nullptr) {}
 
 		/*!
 		 * \brief Destructor
@@ -147,25 +154,14 @@ namespace GS {
 		 */
 		gs_texture_t* GetObject();
 
-		static void init_empty_texture();
-		static gs_texture_t *get_empty_texture();
-		static void add_to_cache(std::string, gs_texture_t*);
-		static void load_from_cache(std::string, gs_texture_t**);
-		static void unload_texture(std::string, gs_texture_t *);
-		static void destroy_pool();
-
-
 		protected:
 		gs_texture_t* m_texture;
 		bool m_destroy;
 		std::string m_name;
 
-		void DestroyTexture();
-
-		// caching, for now only the cubemaps 
-		static const size_t MAX_POOL_SIZE;
-		static std::map<std::string, std::pair<size_t, gs_texture_t*> > pool;
-		static gs_texture_t *empty_texture;
+		// cache manager from FM instance
+		// currently only caching cubemaps
+		Cache *m_cache;
 
 	};
 }

--- a/mask/mask-resource-effect.cpp
+++ b/mask/mask-resource-effect.cpp
@@ -43,7 +43,7 @@ const std::map<std::string, std::string> Mask::Resource::Effect::g_textureTypes 
 };
 
 
-std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, std::string filename)
+std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, std::string filename, Cache *cache)
 {
 	char *file_string;
 	file_string = os_quick_read_utf8_file(filename.c_str());
@@ -83,10 +83,10 @@ std::shared_ptr<GS::Effect> Mask::Resource::Effect::compile(std::string name, st
 	*/
 	std::string code = file_string;
 	bfree(file_string);
-	return std::make_shared<GS::Effect>(code, name);
+	return std::make_shared<GS::Effect>(code, name, cache);
 }
 
-Mask::Resource::Effect::Effect(Mask::MaskData* parent, std::string name, obs_data_t* data)
+Mask::Resource::Effect::Effect(Mask::MaskData* parent, std::string name, obs_data_t* data, Cache *cache)
 	: IBase(parent, name) {
 	const char* const S_DATA = "data";
 	if (!obs_data_has_user_value(data, S_DATA)) {
@@ -102,13 +102,19 @@ Mask::Resource::Effect::Effect(Mask::MaskData* parent, std::string name, obs_dat
 	// write to temp file
 	m_filename = Utils::Base64ToTempFile(base64data);
 	m_filenameIsTemp = true;
+
+	// cache
+	m_cache = cache;
 }
 
-Mask::Resource::Effect::Effect(Mask::MaskData* parent, std::string name, std::string filename)
+Mask::Resource::Effect::Effect(Mask::MaskData* parent, std::string name, std::string filename, Cache *cache)
 	: IBase(parent, name) {
 
 	m_filename = filename;
 	m_filenameIsTemp = false;
+
+	// cache
+	m_cache = cache;
 }
 
 
@@ -128,7 +134,7 @@ void Mask::Resource::Effect::Render(Mask::Part* part) {
 	UNUSED_PARAMETER(part);
 	if (m_Effect == nullptr) {
 
-		m_Effect = Effect::compile(m_name, m_filename);
+		m_Effect = Effect::compile(m_name, m_filename, m_cache);
 
 		if (m_filenameIsTemp) {
 			Utils::DeleteTempFile(m_filename);

--- a/mask/mask-resource-effect.h
+++ b/mask/mask-resource-effect.h
@@ -19,6 +19,7 @@
 #pragma once
 #include "mask-resource.h"
 #include "gs/gs-effect.h"
+#include "mask/mask-resource.h"
 #include <sstream>
 extern "C" {
 	#pragma warning( push )
@@ -32,8 +33,9 @@ namespace Mask {
 	namespace Resource {
 		class Effect : public IBase {
 		public:
-			Effect(Mask::MaskData* parent, std::string name, obs_data_t* data);
-			Effect(Mask::MaskData* parent, std::string name, std::string filename);
+			using Cache = Mask::Resource::Cache;
+			Effect(Mask::MaskData* parent, std::string name, obs_data_t* data, Cache *cache);
+			Effect(Mask::MaskData* parent, std::string name, std::string filename, Cache *cache);
 			virtual ~Effect();
 
 			virtual Type GetType() override;
@@ -42,7 +44,7 @@ namespace Mask {
 			virtual void Render(Mask::Part* part) override;
 
 			static const std::map<std::string, std::string> g_textureTypes;
-			static std::shared_ptr<GS::Effect> compile(std::string name, std::string filename);
+			static std::shared_ptr<GS::Effect> compile(std::string name, std::string filename, Cache *cache);
 
 			void SetActiveTextures(const std::vector<std::string> &textures) { m_active_textures = textures; }
 			std::vector<std::string> GetActiveTextures() { return m_active_textures; }
@@ -56,6 +58,9 @@ namespace Mask {
 
 			// for dynamic shader creation
 			std::vector<std::string> m_active_textures;
+
+			// cache
+			Cache *m_cache;
 		};
 	}
 }

--- a/mask/mask-resource-image.cpp
+++ b/mask/mask-resource-image.cpp
@@ -24,8 +24,8 @@
 
 static const unsigned int MAX_MIP_LEVELS = 32;
 
-Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, obs_data_t* data)
-	: IBase(parent, name), m_width(0), m_height(0), m_fmt(GS_RGBA), m_mipLevels(-1), m_is_cubemap(false) {
+Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, obs_data_t* data, Cache *cache)
+	: IBase(parent, name), m_width(0), m_height(0), m_fmt(GS_RGBA), m_mipLevels(-1), m_is_cubemap(false), m_cache(cache) {
 
 	char mipdat[128];
 	snprintf(mipdat, sizeof(mipdat), S_MIP_DATA, 0);
@@ -206,7 +206,7 @@ Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, obs_data_
 
 	// temp file?
 	if (m_tempFile.length() > 0) {
-		m_Texture = std::make_shared<GS::Texture>(m_tempFile);
+		m_Texture = std::make_shared<GS::Texture>(m_tempFile, m_cache);
 		Utils::DeleteTempFile(m_tempFile);
 		m_tempFile.clear();
 	}
@@ -219,7 +219,7 @@ Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, obs_data_
 					sides_mips[side * m_mipLevels + i] = m_decoded_mips[side * m_mipLevels + i].data();
 				}
 			}
-			m_Texture = std::make_shared<GS::Texture>(m_name, m_width, m_fmt, m_mipLevels, sides_mips, 0);
+			m_Texture = std::make_shared<GS::Texture>(m_name, m_width, m_fmt, m_mipLevels, sides_mips, 0, m_cache);
 			m_decoded_mips.clear();
 		}
 		else {
@@ -227,16 +227,16 @@ Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, obs_data_
 			for (int i = 0; i < m_mipLevels; i++) {
 				mips[i] = m_decoded_mips[i].data();
 			}
-			m_Texture = std::make_shared<GS::Texture>(m_width, m_height, m_fmt, m_mipLevels, mips, 0);
+			m_Texture = std::make_shared<GS::Texture>(m_width, m_height, m_fmt, m_mipLevels, mips, 0, m_cache);
 			m_decoded_mips.clear();
 		}
 	}
 }
 
-Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, std::string filename) 
-	: IBase(parent, name) {
+Mask::Resource::Image::Image(Mask::MaskData* parent, std::string name, std::string filename, Cache *cache)
+	: IBase(parent, name), m_cache(cache) {
 
-	m_Texture = std::make_shared<GS::Texture>(filename);
+	m_Texture = std::make_shared<GS::Texture>(filename, m_cache);
 }
 
 
@@ -257,7 +257,7 @@ void Mask::Resource::Image::Render(Mask::Part* part) {
 
 		// temp file?
 		if (m_tempFile.length() > 0) {
-			m_Texture = std::make_shared<GS::Texture>(m_tempFile);
+			m_Texture = std::make_shared<GS::Texture>(m_tempFile, m_cache);
 			Utils::DeleteTempFile(m_tempFile);
 			m_tempFile.clear();
 		}
@@ -270,7 +270,7 @@ void Mask::Resource::Image::Render(Mask::Part* part) {
 						sides_mips[side * m_mipLevels + i] = m_decoded_mips[side * m_mipLevels + i].data();
 					}
 				}
-				m_Texture = std::make_shared<GS::Texture>(m_name, m_width, m_fmt, m_mipLevels, sides_mips, 0);
+				m_Texture = std::make_shared<GS::Texture>(m_name, m_width, m_fmt, m_mipLevels, sides_mips, 0, m_cache);
 				m_decoded_mips.clear();
 			}
 			else {
@@ -278,7 +278,7 @@ void Mask::Resource::Image::Render(Mask::Part* part) {
 				for (int i = 0; i < m_mipLevels; i++) {
 					mips[i] = m_decoded_mips[i].data();
 				}
-				m_Texture = std::make_shared<GS::Texture>(m_width, m_height, m_fmt, m_mipLevels, mips, 0);
+				m_Texture = std::make_shared<GS::Texture>(m_width, m_height, m_fmt, m_mipLevels, mips, 0, m_cache);
 				m_decoded_mips.clear();
 			}
 		}

--- a/mask/mask-resource-image.h
+++ b/mask/mask-resource-image.h
@@ -21,6 +21,7 @@
 #include "mask-resource.h"
 #include "gs/gs-texture.h"
 #include "mask.h"
+#include "mask-resource.h"
 extern "C" {
 	#pragma warning( push )
 	#pragma warning( disable: 4201 )
@@ -39,8 +40,8 @@ namespace Mask {
 	namespace Resource {
 		class Image : public IBase {
 		public:
-			Image(Mask::MaskData* parent, std::string name, obs_data_t* data);
-			Image(Mask::MaskData* parent, std::string name, std::string filename);
+			Image(Mask::MaskData* parent, std::string name, obs_data_t* data, Cache *cache);
+			Image(Mask::MaskData* parent, std::string name, std::string filename, Cache *cache);
 			virtual ~Image();
 
 			virtual Type GetType() override;
@@ -64,6 +65,7 @@ namespace Mask {
 			
 
 		protected:
+			Cache *m_cache;
 			std::shared_ptr<GS::Texture> m_Texture;
 			bool m_is_cubemap;
 

--- a/mask/mask-resource-material.cpp
+++ b/mask/mask-resource-material.cpp
@@ -332,7 +332,7 @@ Mask::Resource::Material::Material(Mask::MaskData* parent, std::string name, obs
 
 	m_effect->SetActiveTextures(active_textures);
 
-	// early optimization is root of all evil
+	// compile and load effect file
 	m_effect->Render(nullptr);
 }
 
@@ -481,7 +481,8 @@ bool Mask::Resource::Material::Loop(Mask::Part* part, BonesList* bones) {
 				else
 				{
 					gs_eparam_t* param = gs_effect_get_param_by_name(m_effect->GetEffect()->GetObject(), tex_type_ent.first.c_str());
-					gs_texture_t *tex = GS::Texture::get_empty_texture();
+					gs_texture_t *tex = nullptr;
+					m_parent->GetCache()->load_permanent("empty_texture", (void**)&tex);
 					if (param && tex)
 					{
 						gs_effect_set_texture(param, tex);
@@ -496,7 +497,11 @@ bool Mask::Resource::Material::Loop(Mask::Part* part, BonesList* bones) {
 
 		// attach video texture
 		gs_eparam_t* param = gs_effect_get_param_by_name(m_effect->GetEffect()->GetObject(), PARAM_VIDEO_LIGHTING_TEX);
-		gs_texture_t *tex = m_use_video_lighting ? m_parent->GetVideoLightingTexture() : GS::Texture::get_empty_texture();
+		gs_texture_t *tex = nullptr;
+		if (m_use_video_lighting)
+			tex = m_parent->GetVideoLightingTexture();
+		else
+			m_parent->GetCache()->load_permanent("empty_texture", (void**)&tex);
 		if (param && tex)
 		{
 			gs_effect_set_texture(param, tex);

--- a/mask/mask-resource.cpp
+++ b/mask/mask-resource.cpp
@@ -223,6 +223,7 @@ bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, v
 				// can safely replace
 				blog(LOG_DEBUG, "Caching resource (replacing inactive older version): %s", name.c_str());
 				pool[name] = CacheItem(resource);
+				return true;
 			}
 			else
 				throw "Incorrect use of add before calling load";
@@ -230,12 +231,14 @@ bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, v
 		else {
 			blog(LOG_DEBUG, "Caching resource (re-bind): %s", name.c_str());
 			pool[name] = CacheItem(resource);
+			return true;
 		}
 	}
 	else if (pool.size() < POOL_SIZE)
 	{
 		blog(LOG_DEBUG, "Caching resource: %s", name.c_str());
 		pool[name] = CacheItem(resource);
+		return true;
 	}
 	else
 	{
@@ -289,6 +292,7 @@ bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, v
 			// sorry we cannot cache
 			// the pool is full and
 			// no one can leave it currently
+			blog(LOG_DEBUG, "Caching failed because the pool is full, and no one is willing to leave. Resource: %s", name.c_str());
 			return false;
 		}
 
@@ -308,7 +312,7 @@ void Mask::Resource::Cache::load(CacheableType resource_type, std::string name, 
 	}
 	CachePool &pool = pool_it->second;
 	if (pool.find(name) != pool.end()) {
-		//blog(LOG_DEBUG, "Re-using texture: %s", name.c_str());
+		blog(LOG_DEBUG, "Re-using texture: %s", name.c_str());
 		pool[name].active_count++;
 		pool[name].use_count++;
 		*resource_ptr = pool[name].resource;
@@ -404,6 +408,6 @@ void Mask::Resource::Cache::destroy() {
 	}
 
 	obs_leave_graphics();
-	pool_map.clear();
+
 }
 

--- a/mask/mask-resource.cpp
+++ b/mask/mask-resource.cpp
@@ -48,7 +48,7 @@ Mask::Resource::IBase::~IBase() {
 
 }
 
-std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::Load(Mask::MaskData* parent, std::string name, obs_data_t* data) {
+std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::Load(Mask::MaskData* parent, std::string name, obs_data_t* data, Cache *cache) {
 	static const char* const S_TYPE = "type";
 
 	if (!obs_data_has_user_value(data, S_TYPE)) {
@@ -62,7 +62,7 @@ std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::Load(Mask::MaskDat
 	std::string type = obs_data_get_string(data, S_TYPE);
 	if (type == "image") {
 		// Image
-		return std::make_shared<Mask::Resource::Image>(parent, name, data);
+		return std::make_shared<Mask::Resource::Image>(parent, name, data, cache);
 	} 
 	else if (type == "sequence") {
 		// Image Sequence
@@ -70,10 +70,10 @@ std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::Load(Mask::MaskDat
 	}
 	else if (type == "effect") {
 		// Effect Shader
-		return std::make_shared<Mask::Resource::Effect>(parent, name, data);
+		return std::make_shared<Mask::Resource::Effect>(parent, name, data, cache);
 	} 
 	else if (type == "material") {
-		// Material (Combines Images, Effects
+		// Material (Combines Images, Effects)
 		return std::make_shared<Mask::Resource::Material>(parent, name, data);
 	} 
 	else if (type == "mesh") {
@@ -111,7 +111,7 @@ std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::Load(Mask::MaskDat
 	return nullptr;
 }
 
-std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::LoadDefault(Mask::MaskData* parent, std::string name) {
+std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::LoadDefault(Mask::MaskData* parent, std::string name, Cache *cache) {
 	std::shared_ptr<Mask::Resource::IBase> p(nullptr);
 
 	static const std::map<std::string, std::string> g_defaultImages = {
@@ -144,13 +144,15 @@ std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::LoadDefault(Mask::
 		{ "PBR", "effects/pbr.effect" },
 	};
 
-
-	static obs_data_t *g_templates;
+	obs_data_t *g_templates = nullptr;
+	cache->load_permanent("templates", (void **)&g_templates);
 	// load once
 	if (g_templates == nullptr) {
 		// load templates file
 		char* f = obs_module_file("resources/templates.json");
 		g_templates = obs_data_create_from_json_file(f);
+		cache->add_permanent(CacheableType::OBSData, "templates", g_templates);
+		bfree(f);
 	}
 
 	// yield
@@ -160,7 +162,7 @@ std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::LoadDefault(Mask::
 	if (g_defaultImages.find(name) != g_defaultImages.end()) {
 		char* f = obs_module_file(g_defaultImages.at(name).c_str());
 		p = std::make_shared<Mask::Resource::Image>
-			(parent, name, std::string(f));
+			(parent, name, std::string(f), cache);
 		bfree(f);
 	}
 	// mesh?
@@ -174,16 +176,234 @@ std::shared_ptr<Mask::Resource::IBase> Mask::Resource::IBase::LoadDefault(Mask::
 	if (g_defaultEffects.find(name) != g_defaultEffects.end()) {
 		char* f = obs_module_file(g_defaultEffects.at(name).c_str());
 		p = std::make_shared<Mask::Resource::Effect>
-			(parent, name, std::string(f));
+			(parent, name, std::string(f), cache);
 		bfree(f); 
 	}
 	// template?
 	if (obs_data_has_user_value(g_templates, name.c_str())) {
 		obs_data_t* template_data = obs_data_get_obj(g_templates, name.c_str());
-		p = Load(parent, name, template_data);
+		p = Load(parent, name, template_data, cache);
 		obs_data_release(template_data);
 	}
 
 	return p;
+}
+
+
+// ------------------------------------------------------------------------- //
+// Cache Pools
+// ------------------------------------------------------------------------- //
+
+const size_t Mask::Resource::Cache::POOL_SIZE = 10;
+
+bool Mask::Resource::Cache::add_permanent(CacheableType resource_type, std::string name, void *resource) {
+	auto pool_it = permanent_cache.find(name);
+	if (pool_it == permanent_cache.end()) {
+		permanent_cache[name] = std::make_pair(resource_type, resource);
+		return true;
+	}
+	return false;
+}
+
+bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, void *resource) {
+	auto pool_it = pool_map.find(resource_type);
+	if (pool_it == pool_map.end()) {
+		pool_map[resource_type] = CachePool();
+		pool_it = pool_map.find(resource_type);
+	}
+	CachePool &pool = pool_it->second;
+
+	auto it = pool.find(name);
+	if (it != pool.end()) {
+		if (it->second.resource != nullptr)
+		{
+			if (it->second.active_count == 0) {
+				// no one is using the old one
+				// probably a name clash from an older mask load
+				// can safely replace
+				blog(LOG_DEBUG, "Caching resource (replacing inactive older version): %s", name.c_str());
+				pool[name] = CacheItem(resource);
+			}
+			else
+				throw "Incorrect use of add before calling load";
+		}
+		else {
+			blog(LOG_DEBUG, "Caching resource (re-bind): %s", name.c_str());
+			pool[name] = CacheItem(resource);
+		}
+	}
+	else if (pool.size() < POOL_SIZE)
+	{
+		blog(LOG_DEBUG, "Caching resource: %s", name.c_str());
+		pool[name] = CacheItem(resource);
+	}
+	else
+	{
+		// remove the least re-used resource
+		auto min_it = pool.begin();
+		size_t min_ref = min_it->second.use_count;
+		for (auto it = pool.begin(); it != pool.end(); it++)
+		{
+			if (min_ref > it->second.use_count)
+			{
+				min_ref = it->second.use_count;
+				min_it = it;
+			}
+		}
+		// if the least re-used resource is actively used
+		// by 2 or more, we cannot remove it
+		// let's search for the currently least active resource
+		if (min_it->second.active_count > 2)
+		{
+			min_it = pool.begin();
+			min_ref = min_it->second.active_count;
+			for (auto it = pool.begin(); it != pool.end(); it++)
+			{
+				if (min_ref > it->second.active_count)
+				{
+					min_ref = it->second.active_count;
+					min_it = it;
+				}
+			}
+		}
+
+		blog(LOG_DEBUG, "Pool full. Removing least used/active resource: %s, #active = %d, #use = %d",
+			min_it->first.c_str(), min_it->second.active_count, min_it->second.use_count);
+
+		if (min_it->second.active_count == 1)
+		{
+			// only remove from the pool
+			// the one active user will
+			// correctly destruct the resource
+			pool.erase(min_it);
+		}
+		else if (min_it->second.active_count == 0)
+		{
+			// no one were using this resource
+			// let's destruct it ourselves
+			destruct_by_type(min_it->second.resource, resource_type);
+			pool.erase(min_it);
+		}
+		else
+		{
+			// sorry we cannot cache
+			// the pool is full and
+			// no one can leave it currently
+			return false;
+		}
+
+		blog(LOG_DEBUG, "Caching resource: %s", name.c_str());
+
+		pool[name] = CacheItem(resource);
+
+		return true;
+	}
+}
+
+void Mask::Resource::Cache::load(CacheableType resource_type, std::string name, void **resource_ptr) {
+	auto pool_it = pool_map.find(resource_type);
+	if (pool_it == pool_map.end()) {
+		*resource_ptr = nullptr;
+		return;
+	}
+	CachePool &pool = pool_it->second;
+	if (pool.find(name) != pool.end()) {
+		//blog(LOG_DEBUG, "Re-using texture: %s", name.c_str());
+		pool[name].active_count++;
+		pool[name].use_count++;
+		*resource_ptr = pool[name].resource;
+	}
+	else
+		*resource_ptr = nullptr;
+}
+
+void Mask::Resource::Cache::load_permanent(std::string name, void **resource_ptr) {
+	auto item = permanent_cache.find(name);
+	if (item != permanent_cache.end()) {
+		*resource_ptr = item->second.second;
+	}
+	else
+		*resource_ptr = nullptr;
+}
+
+void Mask::Resource::Cache::destruct_by_type(void *resource, CacheableType resource_type) {
+	if (resource == nullptr) return;
+
+	obs_enter_graphics();
+	switch (resource_type)
+	{
+	case CacheableType::Texture:
+	{
+		gs_texture_t *texture = reinterpret_cast<gs_texture_t*>(resource);
+
+		switch (gs_get_texture_type(texture)) {
+		case GS_TEXTURE_2D:
+			gs_texture_destroy(texture);
+			break;
+		case GS_TEXTURE_3D:
+			gs_voltexture_destroy(texture);
+			break;
+		case GS_TEXTURE_CUBE:
+			gs_cubetexture_destroy(texture);
+			break;
+		}
+	}
+	break;
+	case CacheableType::Effect:
+	{
+		gs_effect_t *effect = reinterpret_cast<gs_effect_t*>(resource);
+		gs_effect_destroy(effect);
+	}
+	break;
+	case CacheableType::OBSData:
+	{
+		obs_data_t *data = reinterpret_cast<obs_data_t*>(resource);
+		obs_data_release(data);
+	}
+	break;
+	}
+	obs_leave_graphics();
+}
+
+void Mask::Resource::Cache::try_destroy_resource(std::string name, void *resource, CacheableType resource_type) {
+	// only destroy if the resource is not managed by the pool
+	auto pool_it = pool_map.find(resource_type);
+	if (pool_it == pool_map.end()) return;
+	CachePool &pool = pool_it->second;
+
+	auto it = pool.find(name);
+	if (it == pool.end()) {
+		destruct_by_type(resource, resource_type);
+	}
+	else {
+		blog(LOG_DEBUG, "Delaying destroying managed resource: %s, #active = %d", name.c_str(), it->second.active_count);
+		it->second.active_count--;
+	}
+}
+
+void Mask::Resource::Cache::destroy() {
+	obs_enter_graphics();
+
+	// destroy pool-managed caches
+	for (auto &pool_ent : pool_map)
+	{
+		CachePool &pool = pool_ent.second;
+		for (auto &ent : pool) {
+			blog(LOG_DEBUG, "Cache Destroy: destroying managed resource: %s", ent.first.c_str());
+			destruct_by_type(ent.second.resource, pool_ent.first);
+			ent.second.resource = nullptr;
+		}
+	}
+
+	// destroy permanent cache
+	for (auto &ent : permanent_cache) {
+		blog(LOG_DEBUG, "Cache Destroy: destroying permanent resource: %s", ent.first.c_str());
+		// ent.second = pair<CacheableType, void *resource>
+		destruct_by_type(ent.second.second, ent.second.first);
+		ent.second.second = nullptr;
+	}
+
+	obs_leave_graphics();
+	pool_map.clear();
 }
 

--- a/mask/mask-resource.cpp
+++ b/mask/mask-resource.cpp
@@ -221,7 +221,7 @@ bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, v
 				// no one is using the old one
 				// probably a name clash from an older mask load
 				// can safely replace
-				blog(LOG_DEBUG, "Caching resource (replacing inactive older version): %s", name.c_str());
+				//blog(LOG_DEBUG, "Caching resource (replacing inactive older version): %s", name.c_str());
 				pool[name] = CacheItem(resource);
 				return true;
 			}
@@ -229,14 +229,14 @@ bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, v
 				throw "Incorrect use of add before calling load";
 		}
 		else {
-			blog(LOG_DEBUG, "Caching resource (re-bind): %s", name.c_str());
+			//blog(LOG_DEBUG, "Caching resource (re-bind): %s", name.c_str());
 			pool[name] = CacheItem(resource);
 			return true;
 		}
 	}
 	else if (pool.size() < POOL_SIZE)
 	{
-		blog(LOG_DEBUG, "Caching resource: %s", name.c_str());
+		//blog(LOG_DEBUG, "Caching resource: %s", name.c_str());
 		pool[name] = CacheItem(resource);
 		return true;
 	}
@@ -270,8 +270,8 @@ bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, v
 			}
 		}
 
-		blog(LOG_DEBUG, "Pool full. Removing least used/active resource: %s, #active = %d, #use = %d",
-			min_it->first.c_str(), min_it->second.active_count, min_it->second.use_count);
+		//blog(LOG_DEBUG, "Pool full. Removing least used/active resource: %s, #active = %d, #use = %d",
+		//	min_it->first.c_str(), min_it->second.active_count, min_it->second.use_count);
 
 		if (min_it->second.active_count == 1)
 		{
@@ -292,11 +292,11 @@ bool Mask::Resource::Cache::add(CacheableType resource_type, std::string name, v
 			// sorry we cannot cache
 			// the pool is full and
 			// no one can leave it currently
-			blog(LOG_DEBUG, "Caching failed because the pool is full, and no one is willing to leave. Resource: %s", name.c_str());
+			//blog(LOG_DEBUG, "Caching failed because the pool is full, and no one is willing to leave. Resource: %s", name.c_str());
 			return false;
 		}
 
-		blog(LOG_DEBUG, "Caching resource: %s", name.c_str());
+		//blog(LOG_DEBUG, "Caching resource: %s", name.c_str());
 
 		pool[name] = CacheItem(resource);
 
@@ -312,7 +312,7 @@ void Mask::Resource::Cache::load(CacheableType resource_type, std::string name, 
 	}
 	CachePool &pool = pool_it->second;
 	if (pool.find(name) != pool.end()) {
-		blog(LOG_DEBUG, "Re-using texture: %s", name.c_str());
+		//blog(LOG_DEBUG, "Re-using resource: %s", name.c_str());
 		pool[name].active_count++;
 		pool[name].use_count++;
 		*resource_ptr = pool[name].resource;
@@ -380,7 +380,7 @@ void Mask::Resource::Cache::try_destroy_resource(std::string name, void *resourc
 		destruct_by_type(resource, resource_type);
 	}
 	else {
-		blog(LOG_DEBUG, "Delaying destroying managed resource: %s, #active = %d", name.c_str(), it->second.active_count);
+		//blog(LOG_DEBUG, "Delaying destroying managed resource: %s, #active = %d", name.c_str(), it->second.active_count);
 		it->second.active_count--;
 	}
 }
@@ -393,7 +393,7 @@ void Mask::Resource::Cache::destroy() {
 	{
 		CachePool &pool = pool_ent.second;
 		for (auto &ent : pool) {
-			blog(LOG_DEBUG, "Cache Destroy: destroying managed resource: %s", ent.first.c_str());
+			//blog(LOG_DEBUG, "Cache Destroy: destroying managed resource: %s", ent.first.c_str());
 			destruct_by_type(ent.second.resource, pool_ent.first);
 			ent.second.resource = nullptr;
 		}
@@ -401,7 +401,7 @@ void Mask::Resource::Cache::destroy() {
 
 	// destroy permanent cache
 	for (auto &ent : permanent_cache) {
-		blog(LOG_DEBUG, "Cache Destroy: destroying permanent resource: %s", ent.first.c_str());
+		//blog(LOG_DEBUG, "Cache Destroy: destroying permanent resource: %s", ent.first.c_str());
 		// ent.second = pair<CacheableType, void *resource>
 		destruct_by_type(ent.second.second, ent.second.first);
 		ent.second.second = nullptr;

--- a/mask/mask.cpp
+++ b/mask/mask.cpp
@@ -100,7 +100,8 @@ static const int NUM_DRAW_BUCKETS = 1024;
 static const float BUCKETS_MAX_Z = 10.0f;
 static const float BUCKETS_MIN_Z = -100.0f;
 
-Mask::MaskData::MaskData() : m_data(nullptr), m_morph(nullptr), m_elapsedTime(0.0f) {
+Mask::MaskData::MaskData(Cache *cache) : m_data(nullptr), m_morph(nullptr),
+m_cache(cache), m_elapsedTime(0.0f) {
 	m_drawBuckets = new Mask::SortedDrawObject*[NUM_DRAW_BUCKETS];
 	ClearSortedDrawObjects();
 	m_vidLightTex = nullptr;
@@ -286,8 +287,9 @@ std::shared_ptr<Mask::Resource::IBase> Mask::MaskData::GetResource(const std::st
 	}
 
 	// Default Resources
-	std::shared_ptr<Mask::Resource::IBase> p = Resource::IBase::LoadDefault(this, name);
+	std::shared_ptr<Mask::Resource::IBase> p = Resource::IBase::LoadDefault(this, name, GetCache());
 	if (p) {
+		/*
 		// if resource is an effect, change to name to include active #defines
 		auto effect = std::dynamic_pointer_cast<Mask::Resource::Effect>(p);
 		if (effect) {
@@ -296,6 +298,7 @@ std::shared_ptr<Mask::Resource::IBase> Mask::MaskData::GetResource(const std::st
 			for (const auto &t : effect->GetActiveTextures())
 				res_name += "_" + t;
 		}
+		*/
 		this->AddResource(res_name, p);
 		return p;
 	}
@@ -330,7 +333,7 @@ std::shared_ptr<Mask::Resource::IBase> Mask::MaskData::GetResource(const std::st
 		return nullptr;
 	}
 	try {
-		auto res = Resource::IBase::Load(this, res_name, elmd);
+		auto res = Resource::IBase::Load(this, res_name, elmd, GetCache());
 		if (res) {
 			this->AddResource(res_name, res);
 			obs_data_item_release(&element);

--- a/mask/mask.h
+++ b/mask/mask.h
@@ -103,7 +103,9 @@ namespace Mask {
 
 	class MaskData : public Resource::IAnimationControls {
 	public:
-		MaskData();
+		using Cache = Resource::Cache;
+		using CacheableType = Cache::CacheableType;
+		MaskData(Cache *cache);
 		virtual ~MaskData();
 
 		// data
@@ -173,6 +175,8 @@ namespace Mask {
 		MaskInstanceDatas	instanceDatas;
 		void				ResetInstanceDatas();
 
+		Cache *GetCache() { return m_cache; }
+
 	private:
 		std::shared_ptr<Part> LoadPart(std::string name, obs_data_t* data);
 		static void PartCalcMatrix(Part *part);
@@ -203,5 +207,8 @@ namespace Mask {
 		float				m_introFadeTime;
 		float				m_introDuration;
 		float				m_elapsedTime;
+
+		// cache manager
+		Cache *m_cache;
 	};
 }

--- a/plugin/face-mask-filter.h
+++ b/plugin/face-mask-filter.h
@@ -33,6 +33,7 @@
 
 
 #include "mask/mask.h"
+#include "mask/mask-resource.h"
 
 extern "C" {
 #pragma warning( push )
@@ -107,6 +108,11 @@ namespace Plugin {
 			static bool generate_videos(obs_properties_t *pr, obs_property_t *p, void *data);
 			bool generate_videos(obs_properties_t *pr, obs_property_t *p);
 			cv::Mat convert_frame_to_gray_mat(obs_source_frame* frame);
+
+			// resource cache manager
+			using Cache = Mask::Resource::Cache;
+			using CacheableType = Cache::CacheableType;
+			Cache m_cache;
 			
 		protected:
 			// face detection thread
@@ -161,6 +167,8 @@ namespace Plugin {
 			gs_texrender_t*		vidLightTexRender;
 			gs_texrender_t*		vidLightTexRenderBack;
 			gs_texture_t*		vidLightTex;
+			
+			Cache resource_cache;
 
 			// mask filenames
 			std::string			maskFolder;

--- a/smll/OBSRenderer.hpp
+++ b/smll/OBSRenderer.hpp
@@ -37,14 +37,16 @@
 #include "FaceDetector.hpp"
 #include "DetectionResults.hpp"
 
+#include "mask/mask-resource.h"
+
 namespace smll {
 
 
 	class OBSRenderer 
 	{
 	public:
-
-		OBSRenderer();
+		using Cache = Mask::Resource::Cache;
+		OBSRenderer(Cache *cache);
 		~OBSRenderer();
 
 		void	SetDrawColor(unsigned char red, 


### PR DESCRIPTION
This will fix memory violation edge cases for caching:
1. Refactor caching into one single class
2. Caching is attached to FM instance
3. Solved several edge cases, to make sure memory violation doesn't happen.

Will do some more testing to make sure it is working as expected.