### PR TITLE
Feature/depth improvement

### DIFF
--- a/data/effects/default.effect
+++ b/data/effects/default.effect
@@ -7,6 +7,11 @@ uniform float4x4 TexMat = {
 0.0, 0.0, 0.0, 1.0 };
 uniform float alpha = 1.0;
 
+// DEPTH VARS
+uniform int renderLayer = 0;
+uniform int numRenderLayers = 1;
+uniform float depthBias = 0.0;
+
 sampler_state defaultSampler {
 	Filter = Linear;
 	AddressU = Wrap;
@@ -25,7 +30,13 @@ struct VertDataOut {
 
 VertDataOut VSDefault(VertDataIn v_in) {
 	VertDataOut vert_out;
-	vert_out.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
+	float4x4 infinite_proj = ViewProj;
+	infinite_proj[3][2] = 1.0;
+	vert_out.pos = mul(float4(v_in.pos.xyz, 1.0), infinite_proj);
+	float depth_ratio = 1.0/float(numRenderLayers);
+	float start_depth = renderLayer*depth_ratio;
+	vert_out.pos.z = start_depth + (1.0/(vert_out.pos.w+depthBias))*depth_ratio;
+	vert_out.pos.z *= vert_out.pos.w;
 	vert_out.uv = mul(float4(v_in.uv, 0.0, 1.0), TexMat).xy;
 	return vert_out;
 }

--- a/data/effects/pbr.effect
+++ b/data/effects/pbr.effect
@@ -127,6 +127,11 @@ uniform float shininess = 8.0;
 uniform int transformNormals = 1;
 uniform float alpha = 1.0;
 
+// DEPTH VARS
+uniform int renderLayer = 0;
+uniform int numRenderLayers = 1;
+uniform float depthBias = 0.0;
+
 // TEXTURE SAMPLERS
 sampler_state tex_sampler {
 	Filter    = MIN_MAG_MIP_LINEAR;
@@ -499,7 +504,13 @@ VertDataOut VSPhong(VertDataIn v_in)
 		vintangent = float4(normalize(restangent), 0.0);
 	}
 	
-	vert_out.pos = mul(vinpos, ViewProj);
+	float4x4 infinite_proj = ViewProj;
+	infinite_proj[3][2] = 1.0;
+	vert_out.pos = mul(vinpos, infinite_proj);
+	float depth_ratio = 1.0/float(numRenderLayers);
+	float start_depth = renderLayer*depth_ratio;
+	vert_out.pos.z = start_depth + (1.0/(vert_out.pos.w+depthBias))*depth_ratio;
+	vert_out.pos.z *= vert_out.pos.w;
 	vert_out.vpos = mul(vinpos, World);	
 	
 	if (transformNormals == 1) {

--- a/data/effects/pbr.effect
+++ b/data/effects/pbr.effect
@@ -116,9 +116,6 @@ uniform float3 color_balance = {1.0,1.0,1.0};
 uniform float ibl_intensity = 1.0;
 uniform float3 ibl_rotate_offset = {0.0, 0.0, 0.0};
 
-// PBR Glass
-uniform float glass_spec_ratio = 1.0;
-
 // Emissive
 uniform float emissive_intensity = 10.0;
 
@@ -131,6 +128,9 @@ uniform float alpha = 1.0;
 uniform int renderLayer = 0;
 uniform int numRenderLayers = 1;
 uniform float depthBias = 0.0;
+
+// Cutout threshold for discarding fragments
+uniform float cutoutThreshold = -1.0;
 
 // TEXTURE SAMPLERS
 sampler_state tex_sampler {
@@ -360,6 +360,7 @@ float  lightAngle) {
 
 		float max_ibl_spec = max(lightSpecular.r, max(lightSpecular.g, lightSpecular.b));
 		float max_ibl_spec_reflectivity = max(spec_contrib.r, max(spec_contrib.g, spec_contrib.b));
+		float glass_spec_ratio = cutoutThreshold < 0 ? 1.0 : 0.0;
 		float opacity = albedo.a+(glass_spec_ratio*max_ibl_spec_reflectivity)*max_ibl_spec;
 		opacity = saturate(opacity);
 
@@ -633,6 +634,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 
 		float max_ibl_spec = max(ibl_spec_light.r, max(ibl_spec_light.g, ibl_spec_light.b));
 		float max_ibl_spec_reflectivity = max(kr.r, max(kr.g, kr.b));
+		float glass_spec_ratio = cutoutThreshold < 0 ? 1.0 : 0.0;
 		float opacity = albedoColor.a+(glass_spec_ratio*max_ibl_spec_reflectivity)*max_ibl_spec;
 		opacity = saturate(opacity);
 
@@ -816,6 +818,10 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 	float4 srgb_final_color; 
 	srgb_final_color.rgb = linear_to_srgb(linear_color);
 	srgb_final_color.a = final_color.a;
+	
+	if(cutoutThreshold >= 0.0 && srgb_final_color.a <= cutoutThreshold) discard;
+
+	srgb_final_color.a *= alpha;
 
 	return srgb_final_color;
 }

--- a/data/effects/phong.effect
+++ b/data/effects/phong.effect
@@ -529,7 +529,7 @@ float4 PSPhong(VertDataOut v_in) : TARGET
 			light3Specular,
 			light3Angle);
 	}
-	
+	if(cutoutThreshold >= 0.0 && dffColor.a <= cutoutThreshold) discard;
 	
 	return float4(outColor.rgb, dffColor.a * alpha);
 }

--- a/data/effects/phong.effect
+++ b/data/effects/phong.effect
@@ -94,6 +94,14 @@ uniform float shininess = 8.0;
 uniform int transformNormals = 1;
 uniform float alpha = 1.0;
 
+// DEPTH VARS
+uniform int renderLayer = 0;
+uniform int numRenderLayers = 1;
+uniform float depthBias = 0.0;
+
+// Cutout threshold for discarding fragments
+uniform float cutoutThreshold = -1.0;
+
 
 // TEXTURE SAMPLERS
 sampler_state normalSampler {
@@ -371,7 +379,13 @@ VertDataOut VSPhong(VertDataIn v_in)
 		vintangent = float4(normalize(restangent), 0.0);
 	}
 	
-	vert_out.pos = mul(vinpos, ViewProj);
+	float4x4 infinite_proj = ViewProj;
+	infinite_proj[3][2] = 1.0;
+	vert_out.pos = mul(vinpos, infinite_proj);
+	float depth_ratio = 1.0/float(numRenderLayers);
+	float start_depth = renderLayer*depth_ratio;
+	vert_out.pos.z = start_depth + (1.0/(vert_out.pos.w+depthBias))*depth_ratio;
+	vert_out.pos.z *= vert_out.pos.w;
 	vert_out.vpos = mul(vinpos, World);	
 	
 	if (transformNormals == 1) {

--- a/mask/mask-resource-model.cpp
+++ b/mask/mask-resource-model.cpp
@@ -32,6 +32,9 @@ extern "C" {
 
 static const char* const S_MESH = "mesh";
 static const char* const S_MATERIAL = "material";
+static const char* const S_ORDER = "order";
+static const char* const S_LAYER = "layer";
+static const char* const S_DEPTH_BIAS = "depth-bias";
 
 
 Mask::Resource::Model::Model(Mask::MaskData* parent, std::string name, obs_data_t* data)
@@ -68,6 +71,16 @@ Mask::Resource::Model::Model(Mask::MaskData* parent, std::string name, obs_data_
 		PLOG_ERROR("<Model '%s'> Resolved material dependency on '%s' is not a material.",
 			m_name.c_str(), materialName.c_str());
 		throw std::logic_error("Material dependency of Model is not a material.");
+	}
+
+	if (obs_data_has_user_value(data, S_ORDER)) {
+		m_render_order = obs_data_get_int(data, S_ORDER);
+	}
+	if (obs_data_has_user_value(data, S_LAYER)) {
+		m_render_layer = obs_data_get_int(data, S_LAYER);
+	}
+	if (obs_data_has_user_value(data, S_DEPTH_BIAS)) {
+		m_depth_bias = obs_data_get_double(data, S_DEPTH_BIAS);
 	}
 }
 

--- a/mask/mask-resource-skinned-model.cpp
+++ b/mask/mask-resource-skinned-model.cpp
@@ -39,6 +39,9 @@ static const char* const S_POSITION = "position";
 static const char* const S_ROTATION = "rotation";
 static const char* const S_QROTATION = "qrotation";
 static const char* const S_SCALE = "scale";
+static const char* const S_ORDER = "order";
+static const char* const S_LAYER = "layer";
+static const char* const S_DEPTH_BIAS = "depth-bias";
 
 
 
@@ -200,6 +203,16 @@ Mask::Resource::SkinnedModel::SkinnedModel(Mask::MaskData* parent, std::string n
 	}
 	if (skinsItem) {
 		obs_data_item_release(&skinsItem);
+	}
+
+	if (obs_data_has_user_value(data, S_ORDER)) {
+		m_render_order = obs_data_get_int(data, S_ORDER);
+	}
+	if (obs_data_has_user_value(data, S_LAYER)) {
+		m_render_layer = obs_data_get_int(data, S_LAYER);
+	}
+	if (obs_data_has_user_value(data, S_DEPTH_BIAS)) {
+		m_depth_bias = obs_data_get_double(data, S_DEPTH_BIAS);
 	}
 }
 

--- a/mask/mask.cpp
+++ b/mask/mask.cpp
@@ -27,7 +27,7 @@
 #include "plugin/plugin.h"
 #include "plugin/utils.h"
 
-
+#include <set>
 
 Mask::Part::Part(std::shared_ptr<Part> p_parent,
 	std::shared_ptr<Resource::IBase> p_resource) :
@@ -105,6 +105,7 @@ m_cache(cache), m_elapsedTime(0.0f) {
 	m_drawBuckets = new Mask::SortedDrawObject*[NUM_DRAW_BUCKETS];
 	ClearSortedDrawObjects();
 	m_vidLightTex = nullptr;
+	m_num_render_layers = 1;
 }
 
 Mask::MaskData::~MaskData() {
@@ -249,6 +250,52 @@ void Mask::MaskData::Load(const std::string& file) {
 	if (resources) {
 		obs_data_release(resources);
 	}
+
+	// iterate resources and renumber render layer and order
+	// this will help with both avoid illegal order numbers
+	// and wasting space when layers/orders have gap between them
+	using RenderObj = std::shared_ptr<SortedDrawObject>;
+	auto comp_layer = [](RenderObj a, RenderObj b) {
+		return a->m_render_layer < b->m_render_layer;
+	};
+	auto comp_order = [](RenderObj a, RenderObj b) {
+		return a->m_render_order < b->m_render_order;
+	};
+	std::multiset<RenderObj, decltype(comp_layer)> layer_set(comp_layer);
+	std::multiset<RenderObj, decltype(comp_order)> order_set(comp_order);
+	for (const auto &kv : m_resources) {
+		std::shared_ptr<SortedDrawObject> model = std::dynamic_pointer_cast<SortedDrawObject>(kv.second);
+		if (model)
+		{
+			layer_set.insert(model);
+			order_set.insert(model);
+		}
+	}
+
+	int current_layer = -1;
+	int last_render_layer = -1;
+	for (auto it = layer_set.begin(); it != layer_set.end(); it++)
+	{
+		if (current_layer == -1 || (*it)->m_render_layer > last_render_layer)
+			current_layer++;
+
+		last_render_layer = (*it)->m_render_layer;
+		(*it)->m_render_layer = current_layer;
+	}
+	m_num_render_layers = current_layer + 1;
+
+	int current_order = -1;
+	int last_render_order = -1;
+	for (auto it = order_set.begin(); it != order_set.end(); it++)
+	{
+		if (current_order == -1 || (*it)->m_render_order > last_render_order)
+			current_order++;
+
+		last_render_order = (*it)->m_render_order;
+		(*it)->m_render_order = current_order;
+	}
+	m_num_render_orders = current_order + 1;
+
 }
 
 void Mask::MaskData::AddResource(const std::string& name, std::shared_ptr<Mask::Resource::IBase> resource) {
@@ -510,16 +557,37 @@ void  Mask::MaskData::ClearSortedDrawObjects() {
 }
 
 void  Mask::MaskData::AddSortedDrawObject(SortedDrawObject* obj) {
-	float z = obj->SortDepth();
+	float z = obj->SortDepth() + obj->m_depth_bias;
 	if (z > BUCKETS_MAX_Z)
 		z = BUCKETS_MAX_Z;
 	if (z < BUCKETS_MIN_Z)
 		z = BUCKETS_MIN_Z;
 	z = (z - BUCKETS_MIN_Z) / (BUCKETS_MAX_Z - BUCKETS_MIN_Z);
 	int idx = (int)(z * (float)(NUM_DRAW_BUCKETS - 1));
-	obj->nextDrawObject = m_drawBuckets[idx];
+
+	if (m_drawBuckets[idx] != nullptr)
+	{
+		float z2=m_drawBuckets[idx]->SortDepth();
+		if (z < z2)
+		{
+			// add new obj before current
+			obj->nextDrawObject = m_drawBuckets[idx];
+			m_drawBuckets[idx] = obj;
+		}
+		else
+		{
+			// add it after current
+			obj->nextDrawObject = m_drawBuckets[idx]->nextDrawObject;
+			m_drawBuckets[idx]->nextDrawObject = obj;
+		}
+	}
+	else {
+		obj->nextDrawObject = m_drawBuckets[idx]; // which is nullptr
+		m_drawBuckets[idx] = obj;
+	}
+
 	obj->instanceId = instanceDatas.CurrentId();
-	m_drawBuckets[idx] = obj;
+
 }
 
 void Mask::MaskData::Decompose(const matrix4 *src, vec3 *s, matrix4 *R, vec3 *t)
@@ -796,17 +864,23 @@ void Mask::MaskData::Render(bool depthOnly, bool staticOnly, bool rotationDisabl
 		gs_blend_function_separate(gs_blend_type::GS_BLEND_SRCALPHA,
 			gs_blend_type::GS_BLEND_INVSRCALPHA, gs_blend_type::GS_BLEND_ONE, gs_blend_type::GS_BLEND_ONE);
 
-		for (unsigned int i = 0; i < NUM_DRAW_BUCKETS; i++) {
-			SortedDrawObject* sdo = m_drawBuckets[i];
-			while (sdo) {
-				Part* part = sdo->sortDrawPart;
-				instanceDatas.PushDirect(sdo->instanceId);
-				gs_matrix_push();
-				gs_matrix_mul(&part->global);
-				sdo->SortedRender();
-				gs_matrix_pop();
-				instanceDatas.Pop();
-				sdo = sdo->nextDrawObject;
+		for (size_t current_order = 0; current_order < m_num_render_orders; current_order++)
+		{
+			for (unsigned int i = 0; i < NUM_DRAW_BUCKETS; i++) {
+				SortedDrawObject* sdo = m_drawBuckets[i];
+				while (sdo) {
+					if (sdo->m_render_order == current_order)
+					{
+						Part* part = sdo->sortDrawPart;
+						instanceDatas.PushDirect(sdo->instanceId);
+						gs_matrix_push();
+						gs_matrix_mul(&part->global);
+						sdo->SortedRender();
+						gs_matrix_pop();
+						instanceDatas.Pop();
+					}
+					sdo = sdo->nextDrawObject;
+				}
 			}
 		}
 	}

--- a/mask/mask.h
+++ b/mask/mask.h
@@ -85,7 +85,14 @@ namespace Mask {
 
 	class SortedDrawObject {
 	public:
-
+		SortedDrawObject() {
+			m_render_order = 0;
+			m_render_layer = 0;
+			m_depth_bias = 0.0;
+			sortDrawPart = nullptr;
+			nextDrawObject = nullptr;
+			instanceId = 0;
+		}
 		virtual ~SortedDrawObject() {}
 
 		virtual float	SortDepth() = 0;
@@ -94,6 +101,10 @@ namespace Mask {
 		Part*				sortDrawPart;
 		SortedDrawObject*	nextDrawObject;
 		size_t				instanceId;
+
+		int		m_render_order;
+		int		m_render_layer;
+		float	m_depth_bias;
 	};
 
 	namespace Resource {
@@ -175,6 +186,9 @@ namespace Mask {
 		MaskInstanceDatas	instanceDatas;
 		void				ResetInstanceDatas();
 
+		int GetNumRenderLayers() { return m_num_render_layers; }
+		int GetNumRenderOrders() { return m_num_render_orders; }
+
 		Cache *GetCache() { return m_cache; }
 
 	private:
@@ -198,6 +212,10 @@ namespace Mask {
 
 		// video light data
 		gs_texture_t* m_vidLightTex;
+
+		// render layer and order info
+		int m_num_render_layers;
+		int m_num_render_orders;
 
 		// for certain masks that need to blend with video
 		bool				m_drawVideoWithMask;

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -1110,7 +1110,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 
 				vec4 empty;
 				vec4_zero(&empty);
-				gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &empty, 1.0f, 0);
+				gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &empty, 0.0f, 0);
 
 				while (gs_effect_loop(color_grading_filter_effect, "Draw")) {
 					gs_effect_set_texture(gs_effect_get_param_by_name(color_grading_filter_effect,
@@ -1171,7 +1171,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 				vec4_zero(&black);
 				float vv = (float)0x9a / 255.0f;
 				vec4_set(&thumbbg, vv, vv, vv, 1.0f);
-				gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &black, 1.0f, 0);
+				gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &black, 0.0f, 0);
 
 				if (mask_data) {
 
@@ -1199,11 +1199,11 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 					// if we are generating thumbs
 					if (genThumbs) {
 						// clear the color buffer (leaving depth info there)
-						gs_clear(GS_CLEAR_COLOR, &thumbbg, 1.0f, 0);
+						gs_clear(GS_CLEAR_COLOR, &thumbbg, 0.0f, 0);
 					}
 					else {
 						// clear the color buffer (leaving depth info there)
-						gs_clear(GS_CLEAR_COLOR, &black, 1.0f, 0);
+						gs_clear(GS_CLEAR_COLOR, &black, 0.0f, 0);
 					}
 
 					// draw video to the mask texture?
@@ -1246,7 +1246,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 					}
 
 					if (introActive || outroActive)
-						gs_clear(GS_CLEAR_DEPTH, &black, 1.0f, 0);
+						gs_clear(GS_CLEAR_DEPTH, &black, 0.0f, 0);
 
 					for (int i = 0; i < faces.length; i++) {
 						if (introActive) {
@@ -1565,10 +1565,11 @@ void Plugin::FaceMaskFilter::Instance::drawMaskData(Mask::MaskData*	_maskData,
 
 	gs_set_viewport(0, 0, w, h);
 	gs_enable_depth_test(true);
-	gs_depth_function(GS_LESS);
+	gs_depth_function(GS_GREATER);
 
 	float aspect = (float)w / (float)h;
-	gs_perspective(FOVA(aspect), aspect, NEAR_Z, FAR_Z);
+	// using reversed-z depth with infinite far
+	gs_perspective(FOVA(aspect), aspect, NEAR_Z, 0.0);
 
 	_maskData->Render(depthOnly, staticOnly, rotationDisable);
 


### PR DESCRIPTION
Tools for improving depth buffer and object ordering in the scene:
- **Render Layers:** Move objects to separate layers to avoid unwanted intersections.
- **Render Orders:** Fix the render order for transparent objects to avoid z-fighting and changed ordering due to object movement.
- **Depth Bias:** Make the objects have a bias in their depth value when sorting them. Helps fighting z-fighting.
- **Cutouts:** Will discard fully transparent pixels, to avoid dealing with transparency altogether.