### PR TITLE
Fix emitters crashing slobs

### DIFF
--- a/mask/mask-resource-effect.cpp
+++ b/mask/mask-resource-effect.cpp
@@ -38,7 +38,8 @@ const std::map<std::string, std::string> Mask::Resource::Effect::g_textureTypes 
 			{"iblBRDFTex", "IBL_BRDF_TEX"},
 			{"roughnessTex", "ROUGHNESS_TEX"},
 			{"metalnessTex", "METALNESS_TEX"},
-			{"metallicRoughnessTex", "METALLICROUGHNESS_TEX"}/*,
+			{"metallicRoughnessTex", "METALLICROUGHNESS_TEX"},
+			{"image","EFFECT_DEFAULT_IMAGE"}/*,
 			{"vidLightingTex", "USE_VIDEO_LIGHTING"}*/
 };
 

--- a/mask/mask-resource-material.cpp
+++ b/mask/mask-resource-material.cpp
@@ -527,7 +527,8 @@ bool Mask::Resource::Material::Loop(Mask::Part* part, BonesList* bones) {
 				}
 				else
 				{
-					// use defaul render layer for other model types like emitter
+					// use default render layer for model types that don't have
+					// SortedDrawObject interface, like emitter
 					gs_effect_set_int(param_num_layers, m_parent->GetNumRenderLayers());
 					gs_effect_set_int(param_layer, 0);
 				}

--- a/mask/mask-resource-material.cpp
+++ b/mask/mask-resource-material.cpp
@@ -520,8 +520,17 @@ bool Mask::Resource::Material::Loop(Mask::Part* part, BonesList* bones) {
 			std::shared_ptr<SortedDrawObject> model = std::dynamic_pointer_cast<SortedDrawObject>(part->resources[0]);
 			if (param_num_layers && param_layer)
 			{
-				gs_effect_set_int(param_num_layers, m_parent->GetNumRenderLayers());
-				gs_effect_set_int(param_layer, model->m_render_layer);
+				if (model)
+				{
+					gs_effect_set_int(param_num_layers, m_parent->GetNumRenderLayers());
+					gs_effect_set_int(param_layer, model->m_render_layer);
+				}
+				else
+				{
+					// use defaul render layer for other model types like emitter
+					gs_effect_set_int(param_num_layers, m_parent->GetNumRenderLayers());
+					gs_effect_set_int(param_layer, 0);
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a regression that will crash slobs if we load a mask with emitters. Also, fixes a bug that image for default effect was not bound. This effect is not used currently anymore, but was used before when creating emitters.