### PR TITLE
Fix: morph out of frame crashes slobs

### DIFF
--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -1678,7 +1678,6 @@ int32_t Plugin::FaceMaskFilter::Instance::LocalThreadMain() {
 				}
 				catch (const std::exception&)
 				{
-
 				}
 
 

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -1220,7 +1220,15 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 						if (mask_data && (autoBGRemoval || cartoonMode || demoModeGenPreviews || recordTriggered)) {
 							triangulation.autoBGRemoval = autoBGRemoval;
 							triangulation.cartoonMode = cartoonMode;
-							mask_data->RenderMorphVideo(vidTex, baseWidth, baseHeight, triangulation);
+							try
+							{
+								mask_data->RenderMorphVideo(vidTex, baseWidth, baseHeight, triangulation);
+							}
+							catch (const std::exception&)
+							{
+
+							}
+							
 						}
 
 						// restore transform state
@@ -1321,7 +1329,14 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 	if (mask_data) {
 		triangulation.autoBGRemoval = autoBGRemoval;
 		triangulation.cartoonMode = cartoonMode;
-		mask_data->RenderMorphVideo(vidTex, baseWidth, baseHeight, triangulation);
+		try
+		{
+			mask_data->RenderMorphVideo(vidTex, baseWidth, baseHeight, triangulation);
+		}
+		catch (const std::exception&)
+		{
+
+		}
 	}
 	else {
 		// Draw the source video	
@@ -1656,8 +1671,16 @@ int32_t Plugin::FaceMaskFilter::Instance::LocalThreadMain() {
 
 				// Make the triangulation
 				detection.faces[face_idx].triangulationResults.buildLines = drawMorphTris;
-				smllFaceDetector->MakeTriangulation(detection.frame.morphData,
-					detect_results, detection.faces[face_idx].triangulationResults);
+				try
+				{
+					smllFaceDetector->MakeTriangulation(detection.frame.morphData,
+						detect_results, detection.faces[face_idx].triangulationResults);
+				}
+				catch (const std::exception&)
+				{
+
+				}
+
 
 				detection.frame.active = false;
 

--- a/smll/FaceDetector.cpp
+++ b/smll/FaceDetector.cpp
@@ -489,8 +489,7 @@ namespace smll {
 					vtxMap[vid] = i;
 				}
 				catch (const std::exception& e) {
-					blog(LOG_DEBUG, "[FaceMask] ***** CAUGHT EXCEPTION CV::SUBDIV2D: %s", e.what());
-					blog(LOG_DEBUG, "[FaceMask] ***** whilst adding point %d at (%f,%f)", i, p.x, p.y);
+					// ignore
 				}
 			}
 		}


### PR DESCRIPTION
When morph mask is drawn out of bound of the frame, it crashes slobs
Example reproduce steps:
- try  mask : 3e4ed69f-b07d-4236-9f0e-105ca558199f
- move up your face out of the frame  -> slobs will crash
Fix:
Ignoring exceptions of the division to avoid whole slobs crashes in future generally 
