### PR TITLE
Unify rendering mask data

### DIFF
--- a/mask/mask.cpp
+++ b/mask/mask.cpp
@@ -29,6 +29,11 @@
 
 #include <set>
 
+static float FOVA(float aspect) {
+	// field of view angle matched to focal length for solvePNP
+	return 56.0f / aspect;
+}
+
 Mask::Part::Part(std::shared_ptr<Part> p_parent,
 	std::shared_ptr<Resource::IBase> p_resource) :
 	parent(p_parent), 
@@ -837,8 +842,30 @@ void Mask::MaskData::Tick(float time) {
 	m_elapsedTime += time;
 }
 
-void Mask::MaskData::Render(bool depthOnly, bool staticOnly, bool rotationDisable) {
+void Mask::MaskData::SetTransform(const smll::ThreeDPose& pose, bool billboard)
+{
+	gs_matrix_identity();
+	gs_matrix_translate3f((float)pose.translation[0],
+		(float)pose.translation[1], (float)-pose.translation[2]);
+	if (!billboard) {
+		gs_matrix_rotaa4f((float)pose.rotation[0], (float)pose.rotation[1],
+			(float)-pose.rotation[2], (float)-pose.rotation[3]);
+	}
+}
 
+void Mask::MaskData::Render(const smll::DetectionResults &faces, int width, int height, bool depthOnly) {
+
+	gs_viewport_push();
+	gs_projection_push();
+
+	gs_set_viewport(0, 0, width, height);
+	gs_enable_depth_test(true);
+	gs_depth_function(GS_GREATER);
+
+	float aspect = (float)width / (float)height;
+	// using reversed-z depth with infinite far
+	gs_perspective(FOVA(aspect), aspect, 1.0, 0.0);
+	
 	ClearSortedDrawObjects();
 
 	gs_blend_state_push();
@@ -848,50 +875,83 @@ void Mask::MaskData::Render(bool depthOnly, bool staticOnly, bool rotationDisabl
 		gs_blend_type::GS_BLEND_ZERO);
 	gs_enable_color(true, true, true, true);
 
+	// save a matrix for face transforms
+	gs_matrix_push();
+
 	// OPAQUE
 	for (auto kv : m_parts) {
 		if (kv.second->resources.size() == 0)
 			continue;
 		instanceDatas.Push(kv.second->hash_id);
-		gs_matrix_push();
-		gs_matrix_mul(&kv.second->global);
 		for (auto  it = kv.second->resources.begin();
 			it != kv.second->resources.end(); it++) {
-			if ((*it)->IsDepthOnly() == depthOnly && (*it)->IsStatic() == staticOnly && (*it)->IsRotationDisabled() == rotationDisable) {
+
+			if ((*it)->IsDepthOnly() != depthOnly) continue;
+
+			bool billboard = (*it)->IsRotationDisabled();
+
+			for (int i = 0; i < faces.length; i++) {
+				// NOTE for some reason, some masks
+				// have their depth head set to static
+				if ((*it)->IsStatic() && (*it)->IsDepthOnly() == false)
+					SetTransform(faces[i].startPose, billboard);
+				else
+					SetTransform(faces[i].pose, billboard);
+
+				gs_matrix_push();
+				gs_matrix_mul(&kv.second->global);
+
 				(*it)->Render(kv.second.get());
+
+				gs_matrix_pop();
 			}
 		}
-		gs_matrix_pop();
 		instanceDatas.Pop();
 	}
 
 	// TRANSPARENT
-	if (!depthOnly) {
-		gs_blend_function_separate(gs_blend_type::GS_BLEND_SRCALPHA,
-			gs_blend_type::GS_BLEND_INVSRCALPHA, gs_blend_type::GS_BLEND_ONE, gs_blend_type::GS_BLEND_ONE);
+	gs_blend_function_separate(gs_blend_type::GS_BLEND_SRCALPHA,
+		gs_blend_type::GS_BLEND_INVSRCALPHA, gs_blend_type::GS_BLEND_ONE, gs_blend_type::GS_BLEND_ONE);
 
-		for (size_t current_order = 0; current_order < m_num_render_orders; current_order++)
-		{
-			for (unsigned int i = 0; i < NUM_DRAW_BUCKETS; i++) {
-				SortedDrawObject* sdo = m_drawBuckets[i];
-				while (sdo) {
-					if (sdo->m_render_order == current_order)
-					{
-						Part* part = sdo->sortDrawPart;
-						instanceDatas.PushDirect(sdo->instanceId);
+	for (size_t current_order = 0; current_order < m_num_render_orders; current_order++)
+	{
+		for (unsigned int i = 0; i < NUM_DRAW_BUCKETS; i++) {
+			SortedDrawObject* sdo = m_drawBuckets[i];
+			Resource::IBase* res = dynamic_cast<Resource::IBase*>(sdo);
+			if (!res) continue; // skip if sdo is not a resource type
+			while (sdo) {
+				if (sdo->m_render_order == current_order)
+				{
+					Part* part = sdo->sortDrawPart;
+					instanceDatas.PushDirect(sdo->instanceId);
+					
+					bool billboard = res->IsRotationDisabled();
+
+					for (int i = 0; i < faces.length; i++) {
+						if (res->IsStatic())
+							SetTransform(faces[i].startPose, billboard);
+						else
+							SetTransform(faces[i].pose, billboard);
+
 						gs_matrix_push();
 						gs_matrix_mul(&part->global);
 						sdo->SortedRender();
 						gs_matrix_pop();
-						instanceDatas.Pop();
 					}
-					sdo = sdo->nextDrawObject;
+					instanceDatas.Pop();
 				}
+				sdo = sdo->nextDrawObject;
 			}
 		}
 	}
 
+	gs_matrix_pop();
+
 	gs_blend_state_pop();
+
+	gs_projection_pop();
+	gs_viewport_pop();
+
 }
 
 static const char* const S_POSITION = "position";

--- a/mask/mask.h
+++ b/mask/mask.h
@@ -22,6 +22,7 @@
 #include "mask-instance-data.h"
 #include "mask-resource-morph.h"
 #include "smll/TriangulationResult.hpp"
+#include "smll/DetectionResults.hpp"
 #include <string>
 #include <vector>
 #include <memory>
@@ -140,7 +141,7 @@ namespace Mask {
 
 		// main: tick & render
 		void Tick(float time);
-		void Render(bool depthOnly = false, bool staticOnly = false, bool rotationDisable = false);
+		void Render(const smll::DetectionResults& faces, int width, int height, bool depthOnly = false);
 
 		// IAnimationControls
 		void	Play() override;
@@ -195,6 +196,7 @@ namespace Mask {
 		std::shared_ptr<Part> LoadPart(std::string name, obs_data_t* data);
 		static void PartCalcMatrix(Part *part);
 		static void Decompose(const matrix4 *src, vec3 *s, matrix4 *R, vec3 *t);
+		void SetTransform(const smll::ThreeDPose& pose, bool billboard);
 
 		struct {
 			std::string name;

--- a/plugin/face-mask-filter.cpp
+++ b/plugin/face-mask-filter.cpp
@@ -59,13 +59,6 @@
 // Big enough
 #define BIG_FLOAT					    (100000.0f)
 
-static float FOVA(float aspect) {
-	// field of view angle matched to focal length for solvePNP
-	return 56.0f / aspect;
-}
-
-static const float_t NEAR_Z = 1.0f;
-static const float_t FAR_Z = 15000.0f;
 
 bool gs_rect_equal(const gs_rect& a, const gs_rect& b) {
 	if (a.x != b.x || a.y != b.y || a.cx != b.cx || a.cy != b.cy) {
@@ -1185,16 +1178,7 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 					}
 
 					// Draw depth-only stuff
-					for (int i = 0; i < faces.length; i++) {
-						gs_matrix_push();
-						setFaceTransform(faces[i].pose);
-						drawMaskData(mask_data, true, false, false);
-						drawMaskData(mask_data, true, true, false);
-						setFaceTransform(faces[i].pose, true);
-						drawMaskData(mask_data, true, false, true);
-						drawMaskData(mask_data, true, true, true);
-						gs_matrix_pop();
-					}
+					mask_data->Render(faces, baseWidth * m_scale_rate, baseHeight * m_scale_rate, true);
 
 					// if we are generating thumbs
 					if (genThumbs) {
@@ -1238,19 +1222,8 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 					}
 
 					// Draw regular stuff
-					for (int i = 0; i < faces.length; i++) {
-						if (maskAlpha > 0.0f) {
-							gs_matrix_push();
-							setFaceTransform(faces[i].startPose);
-							drawMaskData(mask_data, false, true, false);
-							setFaceTransform(faces[i].startPose, true);
-							drawMaskData(mask_data, false, true, true);
-							setFaceTransform(faces[i].pose);
-							drawMaskData(mask_data, false, false, false);
-							setFaceTransform(faces[i].pose, true);
-							drawMaskData(mask_data, false, false, true);
-							gs_matrix_pop();
-						}
+					if (maskAlpha > 0.0f) {
+						mask_data->Render(faces, baseWidth * m_scale_rate, baseHeight * m_scale_rate, false);
 					}
 
 					if (introActive || outroActive)
@@ -1258,16 +1231,10 @@ void Plugin::FaceMaskFilter::Instance::video_render(gs_effect_t *effect) {
 
 					for (int i = 0; i < faces.length; i++) {
 						if (introActive) {
-							gs_matrix_push();
-							setFaceTransform(faces[i].pose, true);
-							drawMaskData(introData.get(), false, false, true);
-							gs_matrix_pop();
+							introData->Render(faces, baseWidth* m_scale_rate, baseHeight* m_scale_rate);
 						}
 						if (outroActive) {
-							gs_matrix_push();
-							setFaceTransform(faces[i].pose, true);
-							drawMaskData(outroData.get(), false, false, true);
-							gs_matrix_pop();
+							outroData->Render(faces, baseWidth* m_scale_rate, baseHeight* m_scale_rate);
 						}
 					}
 				}
@@ -1547,43 +1514,6 @@ void Plugin::FaceMaskFilter::Instance::setupRenderingState() {
 	gs_enable_blending(true);
 	gs_blend_function(gs_blend_type::GS_BLEND_SRCALPHA,
 		gs_blend_type::GS_BLEND_INVSRCALPHA);
-}
-
-
-void Plugin::FaceMaskFilter::Instance::setFaceTransform(const smll::ThreeDPose& pose,
-	bool billboard) {
-
-	gs_matrix_identity();
-	gs_matrix_translate3f((float)pose.translation[0],
-		(float)pose.translation[1], (float)-pose.translation[2]);
-	if (!billboard) {
-		gs_matrix_rotaa4f((float)pose.rotation[0], (float)pose.rotation[1],
-			(float)-pose.rotation[2], (float)-pose.rotation[3]);
-	}
-}
-
-
-void Plugin::FaceMaskFilter::Instance::drawMaskData(Mask::MaskData*	_maskData, 
-	bool depthOnly, bool staticOnly, bool rotationDisable){
-
-	gs_viewport_push();
-	gs_projection_push();
-
-	uint32_t w = baseWidth*m_scale_rate;
-	uint32_t h = baseHeight*m_scale_rate;
-
-	gs_set_viewport(0, 0, w, h);
-	gs_enable_depth_test(true);
-	gs_depth_function(GS_GREATER);
-
-	float aspect = (float)w / (float)h;
-	// using reversed-z depth with infinite far
-	gs_perspective(FOVA(aspect), aspect, NEAR_Z, 0.0);
-
-	_maskData->Render(depthOnly, staticOnly, rotationDisable);
-
-	gs_projection_pop();
-	gs_viewport_pop();
 }
 
 int32_t Plugin::FaceMaskFilter::Instance::StaticThreadMain(Instance *ptr) {

--- a/plugin/face-mask-filter.h
+++ b/plugin/face-mask-filter.h
@@ -131,11 +131,7 @@ namespace Plugin {
 			void drawCropRects(int width, int height);
 			void drawMotionRects(int width, int height);
 			void updateFaces();
-			void setFaceTransform(const smll::ThreeDPose& pose,
-				bool billboard = false);
 			void setupRenderingState();
-			void drawMaskData(Mask::MaskData*	maskData, bool depthOnly, 
-				bool staticOnly, bool rotationDisable);
 			gs_texture* RenderSourceTexture(gs_effect_t* effect);
 			void clearFramesActiveStatus();
 


### PR DESCRIPTION
We previously rendered models in a set of calls to `drawMaskData`. After adding the functionality to set render orders, this old way caused an issue, because for example we always drew static masks before everything else.
This PR will unify all the calls for rendering into one place, so we can always be sure they are rendered in the order we want.