### PR TITLE
Fix Depth Bucket Sorting

### DIFF
--- a/mask/mask.h
+++ b/mask/mask.h
@@ -209,7 +209,8 @@ namespace Mask {
 		std::map<std::string, std::shared_ptr<Resource::Animation>> m_animations;
 		obs_data_t* m_data;
 		std::shared_ptr<Mask::Part> m_partWorld;
-		SortedDrawObject**	m_drawBuckets;
+		static const int NUM_DRAW_BUCKETS = 1024;
+		SortedDrawObject*	m_drawBuckets[NUM_DRAW_BUCKETS];
 		Resource::Morph*	m_morph;
 
 		// video light data


### PR DESCRIPTION
This PR improves/fixes several aspects of sorting transparent objects:
1. Fixes an issue where object insertion in the list was not happening correctly
2. Adds code to avoid creating a loop in depth list and will also log this as an error
3. Considers depth bias for all the cases when sorting
4. Simplifies the sorting code to make it more readable